### PR TITLE
Rename from ReactionsRouter to ReachRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Or use script tags and globals.
 ```html
 <script src="https://unpkg.com/@reach/router"></script>
 <script>
-ReactionsRouter.Router;
-ReactionsRouter.Link;
-ReactionsRouter.Redirect;
+ReachRouter.Router;
+ReachRouter.Link;
+ReachRouter.Redirect;
 </script>
 ```
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ import resolve from "rollup-plugin-node-resolve";
 const config = {
   input: "src/index.js",
   output: {
-    name: "ReactionsRouter",
+    name: "ReachRouter",
     globals: {
       react: "React",
       "react-dom": "ReactDOM"


### PR DESCRIPTION
I assume internally it was named `ReactionsRouter` but soon rebranded to `Reach` so this updates rollup config and readme to use the new branding.