### PR TITLE
Wrap propTypes with env check so they can be removed in production builds

### DIFF
--- a/build/babel-preset.js
+++ b/build/babel-preset.js
@@ -6,6 +6,12 @@ const plugins = [
   "transform-object-rest-spread",
   "dev-expression",
   [
+    "transform-react-remove-prop-types",
+    {
+      "mode": "unsafe-wrap"
+    }
+  ],
+  [
     "transform-inline-environment-variables",
     {
       include: ["COMPAT"]

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-inline-environment-variables": "^0.3.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,6 +757,10 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.13.tgz#331cfc05099a808238311d78319c27460d481189"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"


### PR DESCRIPTION
before - "gzipped, the UMD build is 6.23 kB"
after - "gzipped, the UMD build is 6.05 kB"