### PR TITLE
Fix jest config for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "globals": {
       "__DEV__": true
     },
-    "testRegex": ".+\\.test\\.jsx?$"
+    "testRegex": ".+\\.test\\.js$"
   },
   "peerDependencies": {
     "react": "15.x || 16.x || 16.4.0-alpha.0911da3",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,14 @@
   "scripts": {
     "build": "node build/build.js",
     "watch": "watch -p \"src/**/*.js\" -c \"yarn build\"",
-    "test": "jest **/*.test.js --globals '{\"__DEV__\": true }'",
+    "test": "jest",
     "clean": "rm -rf lib es umd index.js"
+  },
+  "jest": {
+    "globals": {
+      "__DEV__": true
+    },
+    "testRegex": ".+\\.test\\.jsx?$"
   },
   "peerDependencies": {
     "react": "15.x || 16.x || 16.4.0-alpha.0911da3",


### PR DESCRIPTION
Running the tests on Windows gives a somewhat cryptic-looking error:

> Invalid testPattern **\\*.test.js|true|}' supplied. Running all tests instead.

This PR moves the configuration into the `"jest"` property in package.json, using the `"testRegex"` option, so that tests should run more consistently across platforms.