### PR TITLE
Pass the component from the primary Router to the FocusHandler.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,7 @@ class RouterImpl extends React.PureComponent {
       // using 'div' for < 16.3 support
       let FocusWrapper = primary ? FocusHandler : component;
       // don't pass any props to 'div'
-      let wrapperProps = primary ? { uri, location, ...domProps } : domProps;
+      let wrapperProps = primary ? { uri, location, component, ...domProps } : domProps;
 
       return (
         <BaseContext.Provider value={{ baseuri: uri, basepath }}>


### PR DESCRIPTION
Fixes #48

When using a primary Router (the default), the component prop was getting overridden as a FocusHandler and wasn't passed on.