### PR TITLE
fix: pass only domProps to non-primary routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -193,7 +193,7 @@ class RouterImpl extends React.PureComponent {
       // don't pass any props to 'div'
       let wrapperProps = primary
         ? { uri, location, component, ...domProps }
-        : { component, ...domProps };
+        : domProps;
 
       return (
         <BaseContext.Provider value={{ baseuri: uri, basepath }}>


### PR DESCRIPTION
Non-primary route wrappers "leak" the component prop to the DOM.

![component prop leaks in dom](https://user-images.githubusercontent.com/41679/41133631-c78ba4ba-6ad0-11e8-9000-fd82d6461ea7.png)

This PR changes wrapperProps to be domProps.