### PR TITLE
fix: destructure "component" argument and pass it as prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -221,11 +221,12 @@ class RouterImpl extends React.PureComponent {
 
 let FocusContext = createNamedContext("Focus");
 
-let FocusHandler = ({ uri, location, ...domProps }) => (
+let FocusHandler = ({ uri, location, component, ...domProps }) => (
   <FocusContext.Consumer>
     {requestFocus => (
       <FocusHandlerImpl
         {...domProps}
+        component={component}
         requestFocus={requestFocus}
         uri={uri}
         location={location}


### PR DESCRIPTION
To avoid future bugs, the component parameter should be destructured and explicitly passed as a prop to ```<FocusHandlerImpl>```.

It now works because it is carried by ...domProps, but I don't think that was the intention.

Alternatively, since all props are being destructured later anyway, ```<FocusHandler>``` could be changed to:

```jsx
let FocusHandler = (props) => (
  <FocusContext.Consumer>
    {requestFocus => (
      <FocusHandlerImpl
        {...props}
        requestFocus={requestFocus}
      />
    )}
  </FocusContext.Consumer>
);
```