### PR TITLE
Make build output paths more specific in .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 package.json
-es
-lib
-umd
+/es
+/index.js
+/lib
+/umd
 website/dist
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -3,7 +3,7 @@ import invariant from "invariant";
 ////////////////////////////////////////////////////////////////////////////////
 // startsWith(string, search) - Check if `string` starts with `search`
 let startsWith = (string, search) => {
-	return string.substr(0, search.length) === search;
+  return string.substr(0, search.length) === search;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -82,7 +82,7 @@ let pick = (routes, uri) => {
       let dynamicMatch = paramRe.exec(routeSegment);
 
       if (dynamicMatch && !isRootUri) {
-        let matchIsNotReserved = (reservedNames.indexOf(dynamicMatch[1]) === -1)
+        let matchIsNotReserved = reservedNames.indexOf(dynamicMatch[1]) === -1;
         invariant(
           matchIsNotReserved,
           `<Router> dynamic segment "${


### PR DESCRIPTION
I noticed utils weren't being formatted inside `src` since ignoring `lib` also caught `src/lib`. Along with that, the root `index.js` created by the build currently gets formatted by Prettier if it exists. 

Wasn't sure if this was what you intended, so this just adds a tighter scope to the build output paths in `.prettierignore`. Also re-ran Prettier to catch the few things inside `src/lib`.