### PR TITLE
Sometimes Link gets undefined to=

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -465,7 +465,7 @@ let Match = ({ path, children }) => (
 
 ////////////////////////////////////////////////////////////////////////////////
 // Junk
-let stripSlashes = str => str.replace(/(^\/+|\/+$)/g, "");
+let stripSlashes = str => str.replace ? str.replace(/(^\/+|\/+$)/g, "") : str;
 
 let createRoute = basepath => element => {
   invariant(


### PR DESCRIPTION
Spent a good half hour on this, turns out wasn't related to the replace property. I would rather not merge this and instead have the proper be called `inPlaceOfCurrent` or something.