### PR TITLE
Fix typo in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ Each example uses create-react-app. To develop against the examples you just nee
 ```
 # from the root of the repository
 yarn link @reach/router
-cd examples/contacts
+cd examples/crud
 yarn && yarn start
 ```
 


### PR DESCRIPTION
In the process of running an example, a typo was found in `examples/README.md`
