### PR TITLE
Add failing test (picked route depends on order)

### DIFF
--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -9,6 +9,15 @@ describe("pick", () => {
     expect(pick(routes, "/").route.value).toBe("root");
   });
 
+  test.only("pick static-nested or dynamic", () => {
+    let routes = [
+      { value: "dynamic", path: "/:foo" },
+      { value: "static-nested", path: "/bar/*" }
+    ];
+
+    expect(pick(routes, "/bar").route.value).toBe("static-nested");
+  });
+
   test("a bunch of scenarios", () => {
     expect(pick(routes, "/").route.value).toBe("Root");
     expect(pick(routes, "/groups/main/users/me").route.value).toBe(

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -9,7 +9,7 @@ describe("pick", () => {
     expect(pick(routes, "/").route.value).toBe("root");
   });
 
-  test.only("pick static-nested or dynamic", () => {
+  test("pick static-nested or dynamic", () => {
     let routes = [
       { value: "dynamic", path: "/:foo" },
       { value: "static-nested", path: "/bar/*" }


### PR DESCRIPTION
In this case result for `/bar` depends on order of routes:
```javascript
<Router>
  <A path="/:foo" />
  <B path="/bar">
    <C default />
  </B>
</Router>
```
gives `<A />`, while
```javascript
<Router>
  <B path="/bar">
    <C default />
  </B>
  <A path="/:foo" />
</Router>
```
gives `<C />`.

It seems like `/bar/*` should be prefered.