### PR TITLE
Create .eslintrc to resolve https://github.com/reach/router/issues/64

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "react-app",
+  "globals": {
+    "__DEV__": true
+  },
+  "rules": {
+    "react/prop-types": ["warn", { "ignore": ["children"] }]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -78,12 +78,6 @@
   "prettier": {
     "printWidth": 80
   },
-  "eslintConfig": {
-    "extends": "react-app",
-    "globals": {
-      "__DEV__": true
-    }
-  },
   "dependencies": {
     "create-react-context": "^0.2.1",
     "invariant": "^2.2.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 import React from "react";
-import warning from "warning";
 import PropTypes from "prop-types";
 import invariant from "invariant";
 import createContext from "create-react-context";
@@ -54,6 +53,10 @@ let Location = ({ children }) => (
 );
 
 class LocationProvider extends React.Component {
+  static propTypes = {
+    history: PropTypes.object
+  };
+
   static defaultProps = {
     history: globalHistory
   };
@@ -141,6 +144,10 @@ let ServerLocation = ({ url, children }) => (
     {children}
   </LocationContext.Provider>
 );
+
+ServerLocation.propTypes = {
+  url: PropTypes.string.isRequired
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Sets baseuri and basepath for nested routers and links


### PR DESCRIPTION
I would like to phase out the issues https://github.com/reach/router/issues/64

First of all, We can find that is missing in props validation 

`.eslintrc`
```
  "rules": {
    "react/prop-types": ["warn", { "ignore": ["children"] }]
  }
```

If all props are validated, how about replacing the warn level with the error?





