### PR TITLE
Create .eslintrc to resolve #64

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "react-app",
+  "globals": {
+    "__DEV__": true
+  },
+  "rules": {
+    "react/prop-types": ["warn", { "ignore": ["children"] }]
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,6 @@
     "__DEV__": true
   },
   "rules": {
-    "react/prop-types": ["warn", { "ignore": ["children"] }]
+    "react/prop-types": ["warn"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,12 +78,6 @@
   "prettier": {
     "printWidth": 80
   },
-  "eslintConfig": {
-    "extends": "react-app",
-    "globals": {
-      "__DEV__": true
-    }
-  },
   "dependencies": {
     "create-react-context": "^0.2.1",
     "invariant": "^2.2.3",

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,10 @@ let Location = ({ children }) => (
 );
 
 class LocationProvider extends React.Component {
+  static propTypes = {
+    history: PropTypes.object.isRequired
+  };
+
   static defaultProps = {
     history: globalHistory
   };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from "react";
 import ReactDOM from "react-dom";
 import renderer from "react-test-renderer";


### PR DESCRIPTION
I would like to phase out the issues https://github.com/reach/router/issues/64

First of all, We can find that is missing in props validation 

`.eslintrc`
```
  "rules": {
    "react/prop-types": ["warn", { "ignore": ["children"] }]
  }
```

If all props are validated, how about replacing the warn level with the error?





