### PR TITLE
Add back functionality to navigate route

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -46,6 +46,12 @@ let createHistory = (source, options) => {
 
     navigate(to, { state, replace = false } = {}) {
       state = { ...state, key: Date.now() + "" };
+
+      if (typeof to === "number") {
+        source.history.go(to);
+        return Promise.resolve();
+      }
+
       // try...catch iOS Safari limits to 100 pushState calls
       try {
         if (transitioning || replace) {

--- a/website/src/markdown/api/navigate.md
+++ b/website/src/markdown/api/navigate.md
@@ -76,7 +76,7 @@ class Invoices extends React.Component {
 
 ## to
 
-The path to navigate to.
+The path to navigate to, or the amount of routes to go back.
 
 ```jsx
 navigate("/some/where")
@@ -86,6 +86,12 @@ If using `props.navigate` in a Route Component, this can be a relative path.
 
 ```jsx
 props.navigate("../")
+```
+
+You can pass a number to go to a previously visited route.
+
+```jsx
+navigate(-1)
 ```
 
 ## option - state


### PR DESCRIPTION
This adds the ability to go back to a previously visited route. It uses the `window.history.go` API.
Resolve #44 