### PR TITLE
Upgrade scroll-into-view-if-needed to 2.2.7 to fix bugs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -38,7 +38,7 @@
     "react": "16.4",
     "react-dom": "16.4",
     "react-media": "^1.8.0",
-    "scroll-into-view-if-needed": "^2.1.5",
+    "scroll-into-view-if-needed": "^2.2.7",
     "serve": "^6.5.8",
     "uglifyjs-webpack-plugin": "^1.2.5",
     "unified": "^6.2.0",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -5970,8 +5970,8 @@ scoped-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
 
 scroll-into-view-if-needed@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.1.5.tgz#0ded69275e0172c71f523722d497aef44f6c6bad"
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.7.tgz#59bb77c65c024da55ff703e7232f7175ceed397f"
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi! Awesome that you're using [scroll-into-view-if-needed](https://github.com/stipsan/scroll-into-view-if-needed)! 🎉 

Since v2.1.5 the following bugs have been fixed:
* don't hide content behind scrollbars.
* `scrollMode: if-needed` still works when the window is scrolled to the bottom.
* Mobile Safari bugs (iPhone X I am looking at you!) got squashed.
* Desktop Safari bug when `document.scrollingElement = body` is fixed.
* Border widths shouldn't prevent elements from scrolling fully into view.