### PR TITLE
Link: Add isCurrentHash to getProps() params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -377,13 +377,14 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
           let href = resolve(to, baseuri);
           let isCurrent = location.pathname === href;
           let isPartiallyCurrent = startsWith(location.pathname, href);
+          let isCurrentHash = `${location.pathname}${location.hash}` === href
 
           return (
             <a
               ref={ref || innerRef}
               aria-current={isCurrent ? "page" : undefined}
               {...anchorProps}
-              {...getProps({ isCurrent, isPartiallyCurrent, href, location })}
+              {...getProps({ isCurrent, isPartiallyCurrent, isCurrentHash, href, location })}
               href={href}
               onClick={event => {
                 if (anchorProps.onClick) anchorProps.onClick(event);


### PR DESCRIPTION
`isCurrentHash` is a parameter similar to `isCurrent` that denotes whether the Link's `href` is an exact match on both the current location's `pathname` and `hash`.