### PR TITLE
fix: pass router location prop to nested paths

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -543,6 +543,35 @@ exports[`passed props passes the matched URI to the component 1`] = `
 </div>
 `;
 
+exports[`passed props router location prop to nested path 1`] = `
+<div
+  role="group"
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  <div>
+    Dash 
+    <div
+      role="group"
+      style={
+        Object {
+          "outline": "none",
+        }
+      }
+      tabIndex="-1"
+    >
+      <div>
+        Reports 
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`passed props shadows params in nested paths 1`] = `
 <div
   role="group"

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,9 @@ class RouterImpl extends React.PureComponent {
         element,
         props,
         element.props.children ? (
-          <Router primary={primary}>{element.props.children}</Router>
+          <Router location={location} primary={primary}>
+            {element.props.children}
+          </Router>
         ) : (
           undefined
         )

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -135,6 +135,24 @@ describe("passed props", () => {
       )
     });
   });
+
+  it("router location prop to nested path", () => {
+    const pathname = "/reports/1";
+    const history = createHistory(createMemorySource(pathname));
+    const location = history.location;
+
+    snapshot({
+      pathname: "/",
+      element: (
+        <Router location={location}>
+          <Dash path="/">
+            <Dash path="/" />
+            <Reports path="reports/:reportId" />
+          </Dash>
+        </Router>
+      )
+    });
+  });
 });
 
 describe("route ranking", () => {


### PR DESCRIPTION
This PR fixes the `location` prop on `<Router />` not being passed to nested paths.

I came across this issue when trying to implement a modals/overlay system similar to React Router v4 in which `location` is captured and stored as `previousLocation` to use on the underlying UI that needs to still display the old location.

Currently this setup won't work with path nesting because the `location` prop is not passed to the cloned nested children that get wrapped in another `<Router />`, only the `primary` prop is passed along.

*Example:*
```
<React.Fragment>
  <Router location={previousLocation}>
    <NestedComponent path="/">
      <Dash path="/" />
      <Test path="test" />
    </NestedComponent>
  </Router>

  <Router>
    <TestModal path="test" />
  </Router>
</React.Fragment>
```

In the example above `<Dash />` and `<Test />`'s `location` prop should match `previousLocation`.

I am assuming this was just overlooked and should be considered a bug, as I can't see any reason why location shouldn't be passed along.

Cheers. 