### PR TITLE
[Link] pass "own" link props to getProps to give more control

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -383,7 +383,10 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
               ref={ref || innerRef}
               aria-current={isCurrent ? "page" : undefined}
               {...anchorProps}
-              {...getProps({ isCurrent, isPartiallyCurrent, href, location })}
+              {...getProps(
+                { isCurrent, isPartiallyCurrent, href, location },
+                anchorProps
+              )}
               href={href}
               onClick={event => {
                 if (anchorProps.onClick) anchorProps.onClick(event);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -432,6 +432,32 @@ describe("links", () => {
       )
     });
   });
+
+  it("passes ownProps (static props) to getProps", done => {
+    let root = document.createElement("div");
+    let passedProps;
+
+    ReactDOM.render(
+      <Link
+        to="/"
+        className="pass-me-down"
+        style={{ color: "red" }}
+        getProps={(_, props) => (passedProps = props)}
+      />,
+      root,
+      () => {
+        expect(passedProps).toMatchObject({
+          className: "pass-me-down",
+          style: {
+            color: "red"
+          }
+        });
+
+        ReactDOM.unmountComponentAtNode(root);
+        done();
+      }
+    );
+  });
 });
 
 describe("transitions", () => {

--- a/website/src/markdown/api/Link.md
+++ b/website/src/markdown/api/Link.md
@@ -45,7 +45,7 @@ Calls up with its inner ref for apps on React <16.4. If using React >=16.4, use 
 <Link to="./" innerRef={node => /* ... */} />
 ```
 
-## getProps: func(obj)
+## getProps: func(obj, ownProps)
 
 Calls up to you to get props for the underlying anchor element. Useful for styling the anchor as active.
 
@@ -79,6 +79,41 @@ const isPartiallyActive = ({
 
 const PartialNavLink = props => (
   <Link getProps={isPartiallyActive} {...props} />
+)
+```
+
+Argument `ownProps` might be useful for controlling result props (passed to anchor).
+E.g. `className`:
+
+```jsx
+// add "active" class to existing one (do not override it)
+const isActive = ({ isCurrent }, ownProps) => {
+  return isCurrent
+    ? { className: `${ownProps.className} active` }
+    : null
+}
+
+// this would be rendered to <a class="my-link active" ...>
+const ExactNavLink = props => (
+  <Link
+    className="my-link"
+    getProps={isActive}
+    {...props}
+  />
+)
+```
+
+or `style`:
+
+```jsx
+// merge inline styles passed to Link and our "active" style
+const isActive = ({ isCurrent }, { style }) => {
+  return isCurrent ? { style: { ...style, color: 'red' } } : null
+}
+
+// this would be rendered to <a class="my-link active" ...>
+const ExactNavLink = props => (
+  <Link style={ textDecoration: "none" } getProps={isActive} {...props} />
 )
 ```
 


### PR DESCRIPTION
## Problem

Currently `getProps` method is not that useful for styling active link.

E.g. to add special class for active link we need to accomplish this:

```jsx
let NavLink =() => (
  <Link
    className="my-link"
    getProps={({ isCurrent }) => isCurrent
      // had to repeat 'my-link'
      ? { className: 'my-link active'}
      : null
    }
  />
)
```

Not that bad actually, but if we are using something like styled-components everything gets more weird - we do not think about `className` usually, styled-components pass it for us:

```jsx

let MyStyledLink = styled(Link)`
  ...
  .active {
    color: red;
  }
`

let NavLink =() => (
  <MyStyledLink
    getProps={({ isCurrent }) => isCurrent
      // this will override class generated by styled-components
      ? { className: 'active' }
      : null
    }
  />
)
```

but we still can add work around:

```jsx
// looks really weird!
let FixedLink = ({ className, ...props }) => (
  <Link
    className={className}
    getProps={({ isCurrent }) =>
      isCurrent ? { className: `${className} active` } : null
    }
    {...props}
  />
)

// new we can style it
let StyledLink = styled(FixedLink)`
  ...
`
```

## Possible solutions

1. Pass "own"/"static" props to `getProps` method (implemented in this PR)
   - users has full control over their props
   - users has to write extra code

   example can be found in updated documentation

1. Internally merge "own"/"static" props with ones returned from `getProps` in more intelligent way
   E.g. do not replace but concatenate `className`s and merge `style` deeply.
   - less flexible way (we cover only some cases)
   - cases covered in the problem section work out of the box

1. Provide `activeClassName` and `activeStyle` from react-router
   - pretty clear solution for exact this problem
   - I guess it wasn't implemented initially cause it is less generic