### PR TITLE
isCurrent supports unicode pathname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /index.js
 /lib
 /compat
+/.idea
 npm-debug.log*
 yarn-error.log*

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -63,6 +63,31 @@ exports[`disrespect has complete disrespect for leading and trailing slashes 1`]
 </div>
 `;
 
+exports[`isCurrent supports unicode 1`] = `
+<a
+  aria-current="page"
+  className="active"
+  href="/✓"
+  onClick={[Function]}
+/>
+`;
+
+exports[`isCurrent works 1`] = `
+<div>
+  <a
+    aria-current="page"
+    className="active"
+    href="/home"
+    onClick={[Function]}
+  />
+  <a
+    aria-current={undefined}
+    href="/not-home"
+    onClick={[Function]}
+  />
+</div>
+`;
+
 exports[`links renders links with relative hrefs 1`] = `
 <div
   role="group"

--- a/src/index.js
+++ b/src/index.js
@@ -375,8 +375,9 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
         {({ location, navigate }) => {
           let { to, state, replace, getProps = k, ...anchorProps } = props;
           let href = resolve(to, baseuri);
-          let isCurrent = location.pathname === href;
-          let isPartiallyCurrent = startsWith(location.pathname, href);
+          let pathname = decodeURI(location.pathname);
+          let isCurrent = pathname === href;
+          let isPartiallyCurrent = startsWith(pathname, href);
 
           return (
             <a

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -31,7 +31,7 @@ let runWithNavigation = (element, pathname = "/") => {
   let wrapper = renderer.create(
     <LocationProvider history={history}>{element}</LocationProvider>
   );
-  const snapshot = string => {
+  const snapshot = () => {
     expect(wrapper.toJSON()).toMatchSnapshot();
   };
   return { history, snapshot, wrapper };
@@ -584,5 +584,30 @@ describe.skip("ServerLocation", () => {
       expect(isRedirect(error)).toBe(true);
       expect(error.uri).toBe("/groups/123");
     }
+  });
+});
+
+describe("isCurrent", () => {
+  const setActive = ({ isCurrent }) => {
+    return isCurrent ? { className: "active" } : null;
+  };
+
+  it("works", () => {
+    snapshot({
+      pathname: "/home",
+      element: (
+        <div>
+          <Link to="/home" getProps={setActive} />
+          <Link to="/not-home" getProps={setActive} />
+        </div>
+      )
+    });
+  });
+
+  it("supports unicode", () => {
+    snapshot({
+      pathname: `/${encodeURI("✓")}`,
+      element: <Link to="/✓" getProps={setActive} />
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,13 +3419,6 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-query-string@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.2.2.tgz#888a6fcb6f76070ba39f2f3025c87099defa1645"
-  dependencies:
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
-
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -3442,9 +3435,9 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.4:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
+react-dom@16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -3468,9 +3461,9 @@ react-test-renderer@16.4:
     prop-types "^15.6.0"
     react-is "^16.4.0"
 
-react@16.4:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
+react@16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -3983,10 +3976,6 @@ stack-utils@^1.0.1:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Problem:

Browser URL: localhost:8080/коровка

`<Link to="/коровка" />` get prop `isCurrent` as false, because:

href: `/коровка`
location.pathname: `/%D0%BA%D0%BE%D1%80%D0%BE%D0%B2%D0%BA%D0%B0`

It looks like location.pathname is always encoded. This pull request is to decode it before comparison.