### PR TITLE
Passes state through to navigate when throwing in a Redirect

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -17,6 +17,22 @@ exports[`Match matches a path 1`] = `
 </pre>
 `;
 
+exports[`Redirect passes state when redirecting 1`] = `
+<div
+  role="group"
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  <p>
+    State passed
+  </p>
+</div>
+`;
+
 exports[`ServerLocation works 1`] = `"<div style=\\"outline:none\\" tabindex=\\"-1\\" role=\\"group\\"><div>Home</div></div>"`;
 
 exports[`ServerLocation works 2`] = `"<div style=\\"outline:none\\" tabindex=\\"-1\\" role=\\"group\\" data-reactroot=\\"\\"><div>Group: <!-- -->123</div></div>"`;

--- a/src/index.js
+++ b/src/index.js
@@ -83,7 +83,7 @@ class LocationProvider extends React.Component {
           history: { navigate }
         }
       } = this;
-      navigate(error.uri, { replace: true });
+      navigate(error.uri, { replace: true, state: error.state });
     } else {
       throw error;
     }
@@ -401,14 +401,15 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
 ));
 
 ////////////////////////////////////////////////////////////////////////////////
-function RedirectRequest(uri) {
+function RedirectRequest(uri, state = {}) {
   this.uri = uri;
+  this.state = state;
 }
 
 let isRedirect = o => o instanceof RedirectRequest;
 
-let redirectTo = to => {
-  throw new RedirectRequest(to);
+let redirectTo = (to, state) => {
+  throw new RedirectRequest(to, state);
 };
 
 class RedirectImpl extends React.Component {
@@ -426,7 +427,7 @@ class RedirectImpl extends React.Component {
     let {
       props: { navigate, to, from, replace, state, noThrow, ...props }
     } = this;
-    if (!noThrow) redirectTo(insertParams(to, props));
+    if (!noThrow) redirectTo(insertParams(to, props), state);
     return null;
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -542,6 +542,35 @@ describe("Match", () => {
   });
 });
 
+describe("Redirect", () => {
+  it("passes state when redirecting", async () => {
+    function UseState({ location }) {
+      const state = (location && location.state) || {};
+
+      if (!state.passedState) {
+        return <p>State not passed</p>;
+      }
+
+      return <p>State passed</p>;
+    }
+
+    const {
+      history: { navigate },
+      snapshot
+    } = runWithNavigation(
+      <Router>
+        <UseState path="/" />
+        <Redirect from="/redirect" to="/" state={{ passedState: true }} />
+      </Router>
+    );
+
+    await navigate("/redirect");
+    await Promise.resolve(); // Not entirely sure why this is necessary, but without it the snapshot is null
+
+    snapshot();
+  });
+});
+
 // React 16.4 is buggy https://github.com/facebook/react/issues/12968
 describe.skip("ServerLocation", () => {
   let App = () => (

--- a/website/src/markdown/api/Redirect.md
+++ b/website/src/markdown/api/Redirect.md
@@ -66,6 +66,14 @@ This indicates which path to redirect to, note the parameters must match the `fr
 <Redirect noThrow />
 ```
 
+## state: object
+
+This is an optional prop that additional information to the `to` route. Please see [navigate](navigate) for more information.
+
+```jsx
+<Redirect state={{ newId: 1 }} />
+```
+
 Redirect works with `componentDidCatch` to prevent the tree from rendering and starts over with a new location.
 
 Because React doesn't swallow the error this might bother you. For example, a redirect will trigger Create React App's error overlay. In production, everything is fine. If it bothers you, add `noThrow` and Redirect will do redirect without using `componentDidCatch`.

--- a/website/src/markdown/api/redirectTo.md
+++ b/website/src/markdown/api/redirectTo.md
@@ -1,4 +1,4 @@
-# redirectTo(uri)
+# redirectTo(uri, state)
 
 React 16+ only. For React < 16 use [`navigate`](navigate) or [Redirect](Redirect).
 
@@ -26,4 +26,12 @@ The uri to redirect to. Must be absolute, it does not support relative paths.
 
 ```jsx
 redirectTo("/somewhere/else")
+```
+
+## state: object
+
+This is an optional prop that additional information to the route. Please see [navigate](navigate) for more information.
+
+```jsx
+redirectTo("/somewhere/else", { newId: 1 })
 ```


### PR DESCRIPTION
### Why?

When working on a side project, I was hoping to be able to do something like this:

```jsx
function AuthorizedPage({ isSignedIn }) {
  if (!isSignedIn) {
    return <Redirect to="/sign-in" state={{ from: '/authorized-page' }} />;
  }

  return <p>Authorized</p>;
}

function SignIn({ isSignedIn, location: { state } }) {
  if (isSignedIn) {
    return <Redirect to={state.from} />;
  }
  
  return <p>Sign In</p>;
}
```

That way, once the user signs in, I can send them back to the page they were on.

### Details

It looks like the `noThrow` implementation of `Redirect` supports this:

https://github.com/reach/router/blob/054187e17795c5c2df289109456ce42c48f49343/src/index.js#L416-L423

But the throw version does not:

https://github.com/reach/router/blob/054187e17795c5c2df289109456ce42c48f49343/src/index.js#L429
https://github.com/reach/router/blob/054187e17795c5c2df289109456ce42c48f49343/src/index.js#L80-L86

### Miscellaneous

If you'd like, I can also add the missing support for `replace` (it currently is always replacing for the throw version, but is configurable for `noThrow`)