### PR TITLE
Create .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{ "presets": ["./build/babel-preset.js"] }


### PR DESCRIPTION
Seems like it *should* be necessary to `yarn build`, but somehow it works without in this repo