### PR TITLE
Pin create-react-context due to non open source licence

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "printWidth": 80
   },
   "dependencies": {
-    "create-react-context": "^0.2.1",
+    "create-react-context": "0.2.1",
     "invariant": "^2.2.3",
     "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.4",


### PR DESCRIPTION
See: https://github.com/react-navigation/react-navigation/issues/4934 for general gist and: https://github.com/jamiebuilds/create-react-context/commit/392ef2b40a4a6239ff63131c03797b7607708040 for the breaking change in a minor version.

Jamiebuilds is acting in bad faith to the open source community and this should not propagate down the line.