### PR TITLE
Add Link APIs for better suspense control

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -11,6 +11,7 @@ let createHistory = (source, options) => {
   let location = getLocation(source);
   let transitioning = false;
   let resolveTransition = () => {};
+  let rejectTransition = () => {};
 
   return {
     get location() {
@@ -57,7 +58,11 @@ let createHistory = (source, options) => {
 
       location = getLocation(source);
       transitioning = true;
-      let transition = new Promise(res => (resolveTransition = res));
+      let transition = new Promise((res, rej) => {
+        rejectTransition();
+        resolveTransition = res;
+        rejectTransition = rej;
+      });
       listeners.forEach(listener => listener({ location, action: "PUSH" }));
       return transition;
     }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -258,4 +258,32 @@ let addQuery = (pathname, query) => pathname + (query ? `?${query}` : "");
 let reservedNames = ["uri", "path"];
 
 ////////////////////////////////////////////////////////////////////////////////
-export { startsWith, pick, match, resolve, insertParams, validateRedirect };
+// makeCancelable as in https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+const makeCancelable = promise => {
+  let hasCanceled_ = false;
+
+  const wrappedPromise = new Promise((resolve, reject) => {
+    promise.then(
+      val => (hasCanceled_ ? reject({ isCanceled: true }) : resolve(val)),
+      error => (hasCanceled_ ? reject({ isCanceled: true }) : reject(error))
+    );
+  });
+
+  return {
+    promise: wrappedPromise,
+    cancel() {
+      hasCanceled_ = true;
+    }
+  };
+};
+
+////////////////////////////////////////////////////////////////////////////////
+export {
+  startsWith,
+  pick,
+  match,
+  resolve,
+  insertParams,
+  validateRedirect,
+  makeCancelable
+};


### PR DESCRIPTION
Compatibility with current API is preserved.

This is based on the idea of curi router [1] that allows also passing
function as children in the Link component that gets the navigating
state as argument.

I've also passed navigating in getProps and if you're interested in this
approach I think the arguments of getProps and children function could
be the same.

This new functionality enables usages like the one below:
```
<Link to="">
  {navigating => <div>Home {navigating && <Spinner />}</div>}
</Link>
```
[1] https://github.com/pshrmn/curi/blob/master/packages/react-dom/src/Link.tsx

NOTE: async/await demands further rollup/babel config so promises were
preferred here.