### PR TITLE
unstable_deferredUpdates is removed from react, replace with rAF

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,11 +22,6 @@ import {
 } from "./lib/history";
 
 ////////////////////////////////////////////////////////////////////////////////
-// React polyfill
-let { unstable_deferredUpdates } = ReactDOM;
-if (unstable_deferredUpdates === undefined) {
-  unstable_deferredUpdates = fn => fn();
-}
 
 const createNamedContext = (name, defaultValue) => {
   const Ctx = createContext(defaultValue);
@@ -102,7 +97,8 @@ class LocationProvider extends React.Component {
     } = this;
     refs.unlisten = history.listen(() => {
       Promise.resolve().then(() => {
-        unstable_deferredUpdates(() => {
+        // TODO: replace rAF with react deferred update API when it's ready https://github.com/facebook/react/issues/13306
+        requestAnimationFrame(() => {
           if (!this.unmounted) {
             this.setState(() => ({ context: this.getContext() }));
           }


### PR DESCRIPTION
See https://github.com/facebook/react/pull/13488

Both `requestIdleCallback` and `requestAnimationFrame` are suggested as alternatives until the API is ready. I went with `requestAnimationFrame` since react already expect you to polyfill it.