### PR TITLE
Add documentation for the Router's component property

### DIFF
--- a/website/src/markdown/api/Router.md
+++ b/website/src/markdown/api/Router.md
@@ -92,3 +92,29 @@ const App = () => (
   </Location>
 )
 ```
+
+## component: component|string
+
+The component that will be used to wrap the Router's children. Defaults to a `<div />`. You can pass in a component or a string matching the name of a DOM element. Any additional props that are passed to the Router will be passed on to the rendered component.
+
+```jsx
+class Container extends React.Component {
+  render () {
+    return (
+      <main>
+        { this.props.children }
+      </main>
+    )
+  }
+}
+
+// Passing a component
+<Router component={Container}>
+  <Dashboard path="/" />
+</Router>
+
+// Passing a string
+<Router component="main" className="container">
+  <Dashboard path="/" />
+</Router>
+```


### PR DESCRIPTION
Helloooooo, 

I was looking for a way to change the element that gets rendered around a router's children, and discovered the handy `component` property while digging around in the source code. Figured I'd add some documentation to make this property easier to find for other folks.

Feel free to replace this content with something better if you'd like.