### PR TITLE
add props for ignoring tabulation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -380,7 +380,7 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
           let href = resolve(to, baseuri);
           let isCurrent = location.pathname === href;
           let isPartiallyCurrent = startsWith(location.pathname, href);
-          let ignoreTab = props.ignoreTab ? "0" : "-1";
+          let ignoreTab = props.ignoreTab ? "-1" : "0";
 
           return (
             <a

--- a/src/index.js
+++ b/src/index.js
@@ -380,6 +380,7 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
           let href = resolve(to, baseuri);
           let isCurrent = location.pathname === href;
           let isPartiallyCurrent = startsWith(location.pathname, href);
+          let ignoreTab = props.ignoreTab ? "0" : "-1";
 
           return (
             <a
@@ -388,6 +389,7 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
               {...anchorProps}
               {...getProps({ isCurrent, isPartiallyCurrent, href, location })}
               href={href}
+              tabIndex={ignoreTab}
               onClick={event => {
                 if (anchorProps.onClick) anchorProps.onClick(event);
                 if (shouldNavigate(event)) {

--- a/website/src/markdown/api/Link.md
+++ b/website/src/markdown/api/Link.md
@@ -116,3 +116,13 @@ You can also pass props you'd like to be on the `<a>` such as a `title`, `id`, `
   onClick={youBet}
 />
 ```
+
+## ingoreTab
+
+Enable ignoring tabulation when your component has focus
+
+```jsx
+<Link to="somewhere" className="whatev" ignoreTab>
+  <Button title="Hello" />
+</Link>
+```


### PR DESCRIPTION
This features need for ignoring focus on tabulation when some component with tabIndex wrapped in <Link>