### PR TITLE
notify error on catch when navigate

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -53,6 +53,7 @@ let createHistory = (source, options) => {
         }
       } catch (e) {
         source.location[replace ? "replace" : "assign"](to);
+        console.error(e);
       }
 
       location = getLocation(source);


### PR DESCRIPTION
When the user calls navigate and something fails throwing an error, catch captures this error and doesn't inform of this. This PR only adds a console error to report this error.