### PR TITLE
Support inline routes with a 'stop' prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -201,15 +201,25 @@ class RouterImpl extends React.PureComponent {
         location,
         navigate: (to, options) => navigate(resolve(to, uri), options)
       };
+      
+      let elementChildren
+      
+      if (element.props.children) {
+        // Check element for a 'stop' prop
+        if (element.props.stop) {
+          // If found, don't wrap children in router
+          elementChildren = element.props.children
+        } else {
+          elementChildren = (
+            <Router primary={primary}>{element.props.children}</Router>
+          )
+        }
+      }
 
       let clone = React.cloneElement(
         element,
         props,
-        element.props.children ? (
-          <Router primary={primary}>{element.props.children}</Router>
-        ) : (
-          undefined
-        )
+        elementChildren
       );
 
       // using 'div' for < 16.3 support

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -340,6 +340,22 @@ describe("nested rendering", () => {
       )
     });
   });
+  
+  it("does not match nested children after stop prop", () => {
+    snapshot({
+      pathname: "/yo",
+      element: (
+        <Router>
+          <div path="/">
+            <div>
+              <div />
+            </div>
+          </div>
+        </Router>
+      )
+    });
+  });
+  
 });
 
 describe("disrespect", () => {


### PR DESCRIPTION
The biggest complaint I get when recommending to friends is the requirement to wrap routes in components. This is just a quick idea I had to support inline routes like so:
```javascript
<Router>
  <div path="/" stop>
    <h2>Welcome</h2>
  </div>
  <div path="dashboard" stop>
    <h2>Dashboard</h2>
  </div>
</Router>
```

I don't like the `stop` prop name and TBH there may be a better implementation, but it temporarily gets the point across. Thoughts?