### PR TITLE
Add a PropType for `to` for Link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -403,6 +403,10 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
   </BaseContext.Consumer>
 ));
 
+Link.propTypes = {
+  to: PropTypes.string.isRequired,
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 function RedirectRequest(uri) {
   this.uri = uri;


### PR DESCRIPTION
I forgot to add the to prop and got:
`Uncaught TypeError: Cannot read property 'substr' of undefined
    at startsWith (utils.js:5)`

Hopefully the PropType will make this super easy to debug.