### PR TITLE
initialPathname for createMemorySource should split out search params

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -67,8 +67,9 @@ let createHistory = (source, options) => {
 ////////////////////////////////////////////////////////////////////////////////
 // Stores history entries in memory for testing or other platforms like Native
 let createMemorySource = (initialPathname = "/") => {
+  let [pathname, search = ""] = initialPathname.split("?");
   let index = 0;
-  let stack = [{ pathname: initialPathname, search: "" }];
+  let stack = [{ pathname, search }];
   let states = [];
 
   return {

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -1,0 +1,13 @@
+import { createMemorySource } from "./history";
+
+describe("createMemorySource", () => {
+  it("creates a memory source with correct pathname", () => {
+    const testHistory = createMemorySource("/test");
+    expect(testHistory.location.pathname).toBe("/test");
+  });
+
+  it("creates a memory source with search", () => {
+    const testHistory = createMemorySource("/test?foo=bar");
+    expect(testHistory.location.search).toBe("foo=bar");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3419,13 +3419,6 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-query-string@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.2.2.tgz#888a6fcb6f76070ba39f2f3025c87099defa1645"
-  dependencies:
-    object-assign "^4.1.0"
-    strict-uri-encode "^1.0.0"
-
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -3442,9 +3435,9 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.4:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
+react-dom@16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -3468,9 +3461,9 @@ react-test-renderer@16.4:
     prop-types "^15.6.0"
     react-is "^16.4.0"
 
-react@16.4:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
+react@16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -3983,10 +3976,6 @@ stack-utils@^1.0.1:
 stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
-
-strict-uri-encode@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
```js
let source = createMemorySource('/test?foo=bar')
```
Now `source.location` looks like this:
```js
{
  pathname: '/test',
  search: 'foo=bar',
  ...
}
```
Rather than this:
```js
{
  pathname: '/test?foo=bar',
  search: '',
  ...
}
```