### PR TITLE
Make <Redirect /> work with relative paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -418,26 +418,43 @@ class RedirectImpl extends React.Component {
   // Support React < 16 with this hook
   componentDidMount() {
     let {
-      props: { navigate, to, from, replace = true, state, noThrow, ...props }
+      props: {
+        navigate,
+        to,
+        from,
+        replace = true,
+        state,
+        noThrow,
+        baseuri,
+        ...props
+      }
     } = this;
     Promise.resolve().then(() => {
-      navigate(insertParams(to, props), { replace, state });
+      let resolvedTo = resolve(to, baseuri);
+      navigate(insertParams(resolvedTo, props), { replace, state });
     });
   }
 
   render() {
     let {
-      props: { navigate, to, from, replace, state, noThrow, ...props }
+      props: { navigate, to, from, replace, state, noThrow, baseuri, ...props }
     } = this;
-    if (!noThrow) redirectTo(insertParams(to, props));
+    let resolvedTo = resolve(to, baseuri);
+    if (!noThrow) redirectTo(insertParams(resolvedTo, props));
     return null;
   }
 }
 
 let Redirect = props => (
-  <Location>
-    {locationContext => <RedirectImpl {...locationContext} {...props} />}
-  </Location>
+  <BaseContext.Consumer>
+    {({ baseuri }) => (
+      <Location>
+        {locationContext => (
+          <RedirectImpl {...locationContext} baseuri={baseuri} {...props} />
+        )}
+      </Location>
+    )}
+  </BaseContext.Consumer>
 );
 
 Redirect.propTypes = {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -491,7 +491,8 @@ describe("relative navigate prop", () => {
       relativeNavigate = navigate;
       return (
         <div>
-          User:{userId}
+          User:
+          {userId}
           {children}
         </div>
       );
@@ -558,11 +559,18 @@ describe("Match", () => {
 
 // React 16.4 is buggy https://github.com/facebook/react/issues/12968
 describe.skip("ServerLocation", () => {
+  let NestedRouter = () => (
+    <Router>
+      <Home path="/home" />
+      <Redirect from="/" to="./home" />
+    </Router>
+  );
   let App = () => (
     <Router>
       <Home path="/" />
       <Group path="/groups/:groupId" />
       <Redirect from="/g/:groupId" to="/groups/:groupId" />
+      <NestedRouter path="/nested/*" />
     </Router>
   );
 
@@ -594,9 +602,25 @@ describe.skip("ServerLocation", () => {
         </ServerLocation>
       );
     } catch (error) {
-      expect(markup).not.toBeDefined();
       expect(isRedirect(error)).toBe(true);
       expect(error.uri).toBe("/groups/123");
     }
+    expect(markup).not.toBeDefined();
+  });
+
+  test("nested redirects", () => {
+    let redirectedPath = "/nested";
+    let markup;
+    try {
+      markup = renderToString(
+        <ServerLocation url={redirectedPath}>
+          <App />
+        </ServerLocation>
+      );
+    } catch (error) {
+      expect(isRedirect(error)).toBe(true);
+      expect(error.uri).toBe("/nested/home");
+    }
+    expect(markup).not.toBeDefined();
   });
 });


### PR DESCRIPTION
This should fix #94

It will also help with #77, although `default` does
1. Not work on <Redirect /> yet
2. Take the whole path as `uri`, and the redirect path is relative to that

So instead it will work with `<Redirect from="/*" to="./relative" />`, as that will slice the uri correctly