### PR TITLE
Add back functionality to navigate route

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -43,16 +43,20 @@ let createHistory = (source, options) => {
     },
 
     navigate(to, { state, replace = false } = {}) {
-      state = { ...state, key: Date.now() + "" };
-      // try...catch iOS Safari limits to 100 pushState calls
-      try {
-        if (transitioning || replace) {
-          source.history.replaceState(state, null, to);
-        } else {
-          source.history.pushState(state, null, to);
+      if (typeof to === "number") {
+        source.history.go(to);
+      } else {
+        state = { ...state, key: Date.now() + "" };
+        // try...catch iOS Safari limits to 100 pushState calls
+        try {
+          if (transitioning || replace) {
+            source.history.replaceState(state, null, to);
+          } else {
+            source.history.pushState(state, null, to);
+          }
+        } catch (e) {
+          source.location[replace ? "replace" : "assign"](to);
         }
-      } catch (e) {
-        source.location[replace ? "replace" : "assign"](to);
       }
 
       location = getLocation(source);

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -1,0 +1,16 @@
+import { createHistory } from "./history";
+
+describe("navigate", () => {
+  test("navigate with number as a first argument", () => {
+    const goMock = jest.fn();
+
+    const mockSource = {
+      history: {
+        go: goMock
+      }
+    };
+    const history = createHistory(mockSource);
+    history.navigate(-1);
+    expect(goMock).toHaveBeenCalledWith(-1);
+  });
+});

--- a/website/src/markdown/api/navigate.md
+++ b/website/src/markdown/api/navigate.md
@@ -88,6 +88,12 @@ If using `props.navigate` in a Route Component, this can be a relative path.
 props.navigate("../")
 ```
 
+You can pass a number to go to a previously visited route.
+
+```jsx
+navigate(-1)
+```
+
 ## option - state
 
 An object to store on location state. This is useful for state that doesn't need to be in the URL but is associated with a route transition. Think of it like "post" data on a server.


### PR DESCRIPTION
Implements #44 

Uses `history.go` as suggested by @ryanflorence in https://github.com/reach/router/issues/44#issuecomment-396368172