### PR TITLE
Expose LocationContext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -530,6 +530,7 @@ let shouldNavigate = event =>
 ////////////////////////////////////////////////////////////////////////
 export {
   Link,
+  LocationContext,
   Location,
   LocationProvider,
   Match,


### PR DESCRIPTION
Exposes `LocationContext`, so it may be used with `static contextType` (and `useContext` when it lands). May need an explanation in the docs as `<Location>` automatically wraps itself in a `<LocationProvider>` when needed, which this won't do.