### PR TITLE
fix: escape pathname in isCurrent check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -378,8 +378,9 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
         {({ location, navigate }) => {
           let { to, state, replace, getProps = k, ...anchorProps } = props;
           let href = resolve(to, baseuri);
-          let isCurrent = location.pathname === href;
-          let isPartiallyCurrent = startsWith(location.pathname, href);
+          let encodedHref = encodeURI(href)
+          let isCurrent = location.pathname === encodedHref;
+          let isPartiallyCurrent = startsWith(location.pathname, encodedHref);
 
           return (
             <a


### PR DESCRIPTION
Currently, a location like `/über` is not recognized as active, because `location.pathname` is escaped, while `href` is not. This should fix it by first `encodeURI`ing `href`.