### PR TITLE
Add ability to pass in custom getLocation 🥳

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -1,4 +1,4 @@
-let getLocation = source => {
+let defaultGetLocation = source => {
   return {
     ...source.location,
     state: source.history.state,
@@ -6,7 +6,9 @@ let getLocation = source => {
   };
 };
 
-let createHistory = (source, options) => {
+let createHistory = (source, options = {}) => {
+  let { getLocation = defaultGetLocation } = options;
+
   let listeners = [];
   let location = getLocation(source);
   let transitioning = false;

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -1,0 +1,28 @@
+import { createHistory, createMemorySource } from "./history";
+
+describe("createHistory", () => {
+  test("should use default getLocation if not passed in through options", () => {
+    let history = createHistory(createMemorySource());
+    expect(history.location).toHaveProperty("pathname", "/");
+  });
+
+  test("should use custom getLocation", () => {
+    let options = {
+      getLocation(source) {
+        const params = new URLSearchParams(source.location.search);
+
+        return {
+          ...source.location,
+          query: params,
+          state: window.history.state,
+          key: (window.history.state && window.history.state.key) || "initial"
+        };
+      }
+    };
+    let history = createHistory(createMemorySource("/"), options);
+    history.navigate("?yo=dawg");
+
+    expect(history.location.query).toBeInstanceOf(URLSearchParams);
+    expect(history.location.query.get("yo")).toEqual("dawg");
+  });
+});

--- a/website/src/markdown/api/createHistory.md
+++ b/website/src/markdown/api/createHistory.md
@@ -15,3 +15,35 @@ let history = createHistory(window)
 let source = createMemorySource("/starting/url")
 let history = createHistory(source)
 ```
+
+There may be times within your screen where you may need to change a part of the
+UI based on some query param. By default we do not parse the search property of the source `location`. To do so we allow you to pass in a custom `getLocation` function into
+the options object. For example:
+
+```jsx
+import {
+  createMemorySource,
+  createHistory
+} from "@reach/router"
+
+let options = {
+  getLocation(source) {
+    const query = new URLSearchParams(
+      source.location.search
+    )
+
+    return {
+      ...source.location,
+      query,
+      state: source.history.state,
+      key:
+        (source.history.state &&
+          source.history.state.key) ||
+        "initial"
+    }
+  }
+}
+
+// listen to the browser history
+let history = createHistory(window, options)
+```

--- a/website/src/markdown/api/createHistory.md
+++ b/website/src/markdown/api/createHistory.md
@@ -16,9 +16,7 @@ let source = createMemorySource("/starting/url")
 let history = createHistory(source)
 ```
 
-There may be times within your screen where you may need to change a part of the
-UI based on some query param. By default we do not parse the search property of the source `location`. To do so we allow you to pass in a custom `getLocation` function into
-the options object. For example:
+There may be times within your screen where you may need to change a part of the UI based on some query param. By default we do not parse the search property of the source `location`. To do so we allow you to pass in a custom `getLocation` function into the options object. For example:
 
 ```jsx
 import {


### PR DESCRIPTION
## Problem
Issue #152 shows that a few application authors were wanting to automatically parse the search property. This way they don't need to implement the parse logic on their end. Some suggested to wrap the history with the own implementation so it would also handle outgoing navigation.

Reach Router with good reason does not handle this because there are so many query parsing libraries out there and not bundling this in it keeps this package small.

## Possible Solution
To help application authors who want to parse the search property into their own query object, Reach Router could allow them to pass in a custom `getLocation` into the options.

## Downsides
This will require users to duplicate the mapping of the source object like you have in the history file. I considered still using the "private" `getLocation` as the default, but was concerned that some users wouldn't want any default logic and they would apply that themselves.

## Changes
### Made options argument a object with a default value
I noticed options is not currently used so I made it an object and used default values for the getLocation. The benefit of this approach is it pushes the responsibility of parsing the search property to the author and adds very little overhead to the package.

### Add tests
I noticed history didn't have any tests, so I added a few for this change. Happy to add more if needed, it seemed most of the logic was already tested in the index.test file.

### Add documentation
For now I just updated the documentation for the createHistory page. Happy to add examples.
