### PR TITLE
Fix for a Link documentation

### DIFF
--- a/website/src/markdown/api/Link.md
+++ b/website/src/markdown/api/Link.md
@@ -91,7 +91,7 @@ const NewsFeed = () => (
   <div>
     <Link
       to="photos/123"
-      state={{ fromNewsFeed: true }}
+      state={{ fromFeed: true }}
     />
   </div>
 )


### PR DESCRIPTION
`fromNewsFeed` state property should match the usage (`fromFeed`) in the example.