### PR TITLE
Fix typo in navigate API

### DIFF
--- a/website/src/markdown/api/navigate.md
+++ b/website/src/markdown/api/navigate.md
@@ -124,7 +124,7 @@ const Todos = props => (
 
 ## option - replace
 
-Normally a call to navigate will push a new entry into the history stack so the user can click the back button to get back to the page. If you pass `replace: false` to `navigate` then the current entry in the history stack will be replaced with the new one.
+Normally a call to navigate will push a new entry into the history stack so the user can click the back button to get back to the page. If you pass `replace: true` to `navigate` then the current entry in the history stack will be replaced with the new one.
 
 An example is when the user clicks a "purchase" button but needs to log in first, after they log in, you can replace the login screen with the checkout screen you wanted them to be at. Then when they click the back button they won't see the login page again.
 


### PR DESCRIPTION
The current route is replaced when `replace: true` is passed, not `false`.