### PR TITLE
Fixed bug: Clicking on a link might lead to `history.replaceState` instead of `history.pushState`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,7 @@ class LocationProvider extends React.Component {
       state: { refs },
       props: { history }
     } = this;
+    history._onTransitionComplete();
     refs.unlisten = history.listen(() => {
       Promise.resolve().then(() => {
         // TODO: replace rAF with react deferred update API when it's ready https://github.com/facebook/react/issues/13306

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import ReactDOM from "react-dom";
+import ReactTestUtils from "react-dom/test-utils";
 import renderer from "react-test-renderer";
 import { renderToString } from "react-dom/server";
 
@@ -445,6 +446,61 @@ describe("links", () => {
         </Router>
       )
     });
+  });
+
+  it("calls history.pushState when clicked", () => {
+    const testSource = createMemorySource("/");
+    testSource.history.replaceState = jest.fn();
+    testSource.history.pushState = jest.fn();
+    const testHistory = createHistory(testSource);
+    const SomePage = () => <Link to="/reports">Go To Reports</Link>;
+    const div = document.createElement("div");
+    ReactDOM.render(
+      <LocationProvider history={testHistory}>
+        <Router>
+          <SomePage path="/" />
+          <Reports path="/reports" />
+        </Router>
+      </LocationProvider>,
+      div
+    );
+    try {
+      const a = div.querySelector("a");
+      ReactTestUtils.Simulate.click(a, { button: 0 });
+      expect(testSource.history.pushState).toHaveBeenCalled();
+    } finally {
+      ReactDOM.unmountComponentAtNode(div);
+    }
+  });
+
+  it("calls history.pushState when clicked -- even if navigated before", () => {
+    const testSource = createMemorySource("/#payload=...");
+    const { history } = testSource;
+    history.replaceState = jest.fn(history.replaceState.bind(history));
+    history.pushState = jest.fn(history.pushState.bind(history));
+    const testHistory = createHistory(testSource);
+    // Simulate that payload in URL hash is being hidden
+    // before React renders anything ...
+    testHistory.navigate("/", { replace: true });
+    expect(testSource.history.replaceState).toHaveBeenCalled();
+    const SomePage = () => <Link to="/reports">Go To Reports</Link>;
+    const div = document.createElement("div");
+    ReactDOM.render(
+      <LocationProvider history={testHistory}>
+        <Router>
+          <SomePage path="/" />
+          <Reports path="/reports" />
+        </Router>
+      </LocationProvider>,
+      div
+    );
+    try {
+      const a = div.querySelector("a");
+      ReactTestUtils.Simulate.click(a, { button: 0 });
+      expect(testSource.history.pushState).toHaveBeenCalled();
+    } finally {
+      ReactDOM.unmountComponentAtNode(div);
+    }
   });
 });
 


### PR DESCRIPTION
I stumbled over this bug, when we called `navigate` in our web app to "beautify" the URL shown in the browser window. When `navigate` is called, **before** React renders anything, then `history._onTransitionComplete()` is not called. (It is currently only called by `LocationProvider.componentDidUpdate`). Therefore `history.transitioning` remains `true` and when the user clicks on the first link, `history.replaceState(...)` is incorrectly called instead of `history.pushState(...)`. This seems to work fine first, but when the user clicks on the back button of the browser, the browser navigates 2 pages back (instead of one).

I fxied this issue by adding a call to `history._onTransitionComplete()` to the `LocationProvider.componentDidMount` method.