### PR TITLE
Make <ServerLocation> parse pathname, search and hash same as on client

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -214,6 +214,36 @@ exports[`links uses the right href in multiple root paths 1`] = `
 </div>
 `;
 
+exports[`location correctly parses pathname, search and hash fields 1`] = `
+<div
+  role="group"
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  <div>
+    <div>
+      location.pathname: [
+      /print-location
+      ]
+    </div>
+    <div>
+      location.search: [
+      ?it=works&with=queries
+      ]
+    </div>
+    <div>
+      location.hash: [
+      #and-hashes
+      ]
+    </div>
+  </div>
+</div>
+`;
+
 exports[`nested rendering matches multiple nested / down to a child with a path 1`] = `
 <div
   role="group"

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -6,6 +6,7 @@ exports[`Match matches a path 1`] = `
   "location": {
     "pathname": "/groups/123",
     "search": "",
+    "hash": "",
     "key": "initial"
   },
   "match": {
@@ -582,6 +583,7 @@ exports[`passed props passes the matched URI to the component 1`] = `
   "location": {
     "pathname": "/groups/123/users/456",
     "search": "",
+    "hash": "",
     "key": "initial"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -583,22 +583,3 @@ export {
   redirectTo,
   globalHistory
 };
-
-// describe("location", () => {
-//   it("correctly parses pathname, search and hash fields", () => {
-//     let testHistory = createHistory(createMemorySource(
-//       '/print-location',
-//       '?it=works&with=queries',
-//       '#and-hashes',
-//       ));
-//     let wrapper = renderer.create(
-//       <LocationProvider history={testHistory}>
-//         <Router>
-//           <PrintLocation path="/print-location" />
-//         </Router>
-//       </LocationProvider>
-//     );
-//     const tree = wrapper.toJSON();
-//     expect(tree).toMatchSnapshot();
-//   });
-// });

--- a/src/index.js
+++ b/src/index.js
@@ -128,23 +128,46 @@ class LocationProvider extends React.Component {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-let ServerLocation = ({ url, children }) => (
-  <LocationContext.Provider
-    value={{
-      location: {
-        pathname: url,
-        search: "",
-        hash: ""
-      },
-      navigate: () => {
-        throw new Error("You can't call navigate on the server.");
-      }
-    }}
-  >
-    {children}
-  </LocationContext.Provider>
-);
+let ServerLocation = ({ url, children }) => {
+  let searchIndex = url.indexOf("?");
+  let hashIndex = url.indexOf("#");
+  let hashExists = hashIndex > -1;
+  let searchExists = searchIndex > -1;
+  let pathname;
+  let search = "";
+  let hash = "";
 
+  if (searchExists && hashExists) {
+    pathname = url.substring(0, searchIndex);
+    search = url.substring(searchIndex, hashIndex);
+    hash = url.substring(hashIndex);
+  } else if (searchExists) {
+    pathname = url.substring(0, searchIndex);
+    search = url.substring(searchIndex);
+  } else if (hashExists) {
+    pathname = url.substring(0, hashIndex);
+    hash = url.substring(hashIndex);
+  } else {
+    pathname = url;
+  }
+
+  return (
+    <LocationContext.Provider
+      value={{
+        location: {
+          pathname,
+          search,
+          hash
+        },
+        navigate: () => {
+          throw new Error("You can't call navigate on the server.");
+        }
+      }}
+    >
+      {children}
+    </LocationContext.Provider>
+  );
+};
 ////////////////////////////////////////////////////////////////////////////////
 // Sets baseuri and basepath for nested routers and links
 let BaseContext = createNamedContext("Base", { baseuri: "/", basepath: "/" });
@@ -560,3 +583,22 @@ export {
   redirectTo,
   globalHistory
 };
+
+// describe("location", () => {
+//   it("correctly parses pathname, search and hash fields", () => {
+//     let testHistory = createHistory(createMemorySource(
+//       '/print-location',
+//       '?it=works&with=queries',
+//       '#and-hashes',
+//       ));
+//     let wrapper = renderer.create(
+//       <LocationProvider history={testHistory}>
+//         <Router>
+//           <PrintLocation path="/print-location" />
+//         </Router>
+//       </LocationProvider>
+//     );
+//     const tree = wrapper.toJSON();
+//     expect(tree).toMatchSnapshot();
+//   });
+// });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -564,6 +564,27 @@ describe("Match", () => {
   });
 });
 
+describe("location", () => {
+  it("correctly parses pathname, search and hash fields", () => {
+    let testHistory = createHistory(
+      createMemorySource(
+        "/print-location",
+        "?it=works&with=queries",
+        "#and-hashes"
+      )
+    );
+    let wrapper = renderer.create(
+      <LocationProvider history={testHistory}>
+        <Router>
+          <PrintLocation path="/print-location" />
+        </Router>
+      </LocationProvider>
+    );
+    const tree = wrapper.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});
+
 // React 16.4 is buggy https://github.com/facebook/react/issues/12968
 // so some tests are skipped
 describe("ServerLocation", () => {

--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -66,9 +66,19 @@ let createHistory = (source, options) => {
 
 ////////////////////////////////////////////////////////////////////////////////
 // Stores history entries in memory for testing or other platforms like Native
-let createMemorySource = (initialPathname = "/") => {
+let createMemorySource = (
+  initialPathname = "/",
+  initialSearch = "",
+  initialHash = ""
+) => {
   let index = 0;
-  let stack = [{ pathname: initialPathname, search: "" }];
+  let stack = [
+    {
+      pathname: initialPathname,
+      search: initialSearch,
+      hash: initialHash
+    }
+  ];
   let states = [];
 
   return {


### PR DESCRIPTION
This is a bugfix PR.

I noticed that the `<ServerLocation>` component doesn't parse `pathname` `search` and `hash` in the same way as on the client, which means that components that depend on values in `location.search` and `location.hash` don't render the same on server renders as they do on the client.

For instance, with the url `/my-page?a=foo#bar` and this component

```jsx
// returns { key:value } of params or {} if search is empty
const parseQueryParams = (search) => ...

const MyPage = ({ location }) => {
  const query = parseQueryParams(location.search)

  return ( 
    <div>pathname: [{location.pathname}] query: [{query.a}] hash: [{location.hash}]</div> 
  )
}

...

<Router>
  <MyPage path='/my-page' />
</Router>
```

On the client this renders `<div>pathname: [/my-page] query: [foo] hash: [bar]</div>`

Whilst on the server, it renders  `<div>pathname: [/my-page?a=foo#bar] query: [] hash: []</div>`

This is using

```jsx
<ServerLocation url='/my-page?a=foo#bar'>...</ServerLocation>
```

Notice how on the server, instead of `pathname` `search` and `hash` being parsed out  from `url` into their respective `location` fields, the entire `url` just gets put in `pathname` and `search` and `hash` are empty -- this is the bug.

---

My PR changes explained:

- 1st commit: Introduce a failing test, showing the above behaviour. You can run this test to verify what I've said above is true.
- 2nd commit: Fix the failing test by making <ServerLocation /> parse the fields the same way as on the client - i.e. fix the bug.
- 3rd commit: New passing test verifying same behaviour on the client
- 4th commit: Update snapshots for 2 other tests which changed due to some necessary changes in the test utils to include search and hash in route test history.