### PR TITLE
Fix example's if/then/else order

### DIFF
--- a/website/src/markdown/api/Match.md
+++ b/website/src/markdown/api/Match.md
@@ -47,8 +47,8 @@ Any params in your the path will be parsed and passed as `match[param]` to your 
   {props => (
     <div>
       {props.match
-        ? "No match"
-        : props.match.eventId}
+        ? props.match.eventId
+        : "No match"}
     </div>
   )}
 </Match>


### PR DESCRIPTION
The "props.match\[param\]: string" section had an example (props.match ? false : true) that was backwards. Switched the arguments to match the intended usage.