### PR TITLE
Add support for fragments

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -17,6 +17,22 @@ exports[`Match matches a path 1`] = `
 </pre>
 `;
 
+exports[`Router children allows for fragments 1`] = `
+<div
+  role="group"
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  <div>
+    Annual Report
+  </div>
+</div>
+`;
+
 exports[`Router children ignores falsey chidlren 1`] = `
 <div
   role="group"

--- a/src/index.js
+++ b/src/index.js
@@ -179,7 +179,15 @@ class RouterImpl extends React.PureComponent {
       component = "div",
       ...domProps
     } = this.props;
-    let routes = React.Children.map(children, createRoute(basepath));
+    let routes = React.Children.toArray(children).reduce((array, child) => {
+      const routes = createRoute(basepath)(child);
+      if (routes instanceof Array) {
+        return array.concat(routes);
+      } else {
+        array.push(routes);
+        return array;
+      }
+    }, []);
     let { pathname } = location;
 
     let match = pick(routes, pathname);
@@ -496,6 +504,9 @@ let createRoute = basepath => element => {
     return null;
   }
 
+  if (element.type === React.Fragment && element.props.children) {
+    return React.Children.map(element.props.children, createRoute(basepath));
+  }
   invariant(
     element.props.path || element.props.default || element.type === Redirect,
     `<Router>: Children of <Router> must have a \`path\` or \`default\` prop, or be a \`<Redirect>\`. None found on element type \`${

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -87,6 +87,20 @@ describe("Router children", () => {
       )
     });
   });
+  it.only("allows for fragments", () => {
+    snapshot({
+      pathname: "/report",
+      element: (
+        <Router>
+          <Home path="/" />
+          <React.Fragment>
+            <Dash path="/dash" />
+            <AnnualReport path="/report" />
+          </React.Fragment>
+        </Router>
+      )
+    });
+  });
 });
 
 describe("passed props", () => {


### PR DESCRIPTION
This pull request adds support for using fragments directly inside of Router components, test included.

Here's what happens when you add a fragment today: https://codesandbox.io/s/festive-sutherland-5b9rf

This pull request fixes this error by checking whether a fragment is present, and if so, traverses the children of that fragment recursively.

Fixes #181 