### PR TITLE
fixed for utils.js/resolve

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -162,7 +162,7 @@ let resolve = (to, base) => {
   }
 
   // profile, /users/789 => /users/789/profile
-  if (!startsWith(toSegments[0], ".")) {
+  if (!/\/?\./.test(toPathname)) {
     let pathname = baseSegments.concat(toSegments).join("/");
     return addQuery((basePathname === "/" ? "" : "/") + pathname, toQuery);
   }
@@ -172,7 +172,7 @@ let resolve = (to, base) => {
   // ../..      /users/123  =>  /
   // ../../one  /a/b/c/d    =>  /a/b/one
   // .././one   /a/b/c/d    =>  /a/b/c/one
-  let allSegments = baseSegments.concat(toSegments);
+  let allSegments = baseSegments.concat(toSegments).filter(Boolean);
   let segments = [];
   for (let i = 0, l = allSegments.length; i < l; i++) {
     let segment = allSegments[i];
@@ -242,9 +242,8 @@ let rankRoute = (route, index) => {
 let rankRoutes = routes =>
   routes
     .map(rankRoute)
-    .sort(
-      (a, b) =>
-        a.score < b.score ? 1 : a.score > b.score ? -1 : a.index - b.index
+    .sort((a, b) =>
+      a.score < b.score ? 1 : a.score > b.score ? -1 : a.index - b.index
     );
 
 let segmentize = uri =>

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -84,6 +84,10 @@ describe("resolve", () => {
     expect(resolve("/groups?some=query", "/users?some=thing")).toEqual(
       "/groups?some=query"
     );
+    expect(resolve("users/.././users", "/")).toEqual("/users");
+    expect(resolve("some/.././users/../info/./address", "/users")).toEqual(
+      "/users/info/address"
+    );
   });
 });
 


### PR DESCRIPTION
as the test case:

```javascript
resolve("users/.././users", "/");   // will feedback '/users/.././users'
```
so, i fixed it, and it's feedback '/users' now.

ps: 
1. This project is great, but is it not maintained?
2. if run `npm run test` got a error info  just like `SecurityError: localStorage is not available for opaque origins`, can add a jest config: "testURL": "http://localhost".