### PR TITLE
Add displayName to Link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -428,6 +428,8 @@ let Link = forwardRef(({ innerRef, ...props }, ref) => (
   </BaseContext.Consumer>
 ));
 
+Link.displayName = "Link";
+
 Link.propTypes = {
   to: PropTypes.string.isRequired
 };


### PR DESCRIPTION
This PR adds a `displayName` of `Link` to the `Link` component.

By reading the [Forwarding Refs](https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools) docs you can do both, name the function passed to `forwardRef` or set the `displayName`.

I've added the `displayName` because I like it being explicit, but I could change it to a named function.

Closes #291