### PR TITLE
Fix the getProps example

### DIFF
--- a/website/src/markdown/api/Link.md
+++ b/website/src/markdown/api/Link.md
@@ -60,7 +60,7 @@ Argument `obj` Properties:
 // this is only active when the location pathname is exactly
 // the same as the href.
 const isActive = ({ isCurrent }) => {
-  return isCurrent ? { className: "active" } : null
+  return isCurrent ? { className: "active" } : {}
 }
 
 const ExactNavLink = props => (
@@ -74,7 +74,7 @@ const isPartiallyActive = ({
 }) => {
   return isPartiallyCurrent
     ? { className: "active" }
-    : null
+    : {}
 }
 
 const PartialNavLink = props => (


### PR DESCRIPTION
According to [the source code](https://github.com/reach/router/blob/master/src/index.js#L414) the `getProps` function cannot return `null`.
I noticed it because of the [DefinitelyTyped types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/reach__router/index.d.ts#L54) and, looking at the source code, the DefinitelyTyped version is right.