### PR TITLE
go method added into MemorySource for best compatibility

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -110,6 +110,15 @@ let createMemorySource = (initialPath = "/") => {
         let [pathname, search = ""] = uri.split("?");
         stack[index] = { pathname, search };
         states[index] = state;
+      },
+      go(to) {
+        let newIndex = index + to;
+
+        if (newIndex < 0 || newIndex > states.length - 1) {
+          return;
+        }
+
+        index = newIndex;
       }
     }
   };

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -13,22 +13,28 @@ describe("createMemorySource", () => {
 });
 
 describe("navigate", () => {
-  test("navigate with number as a first argument", () => {
-    const goMock = jest.fn();
-
-    const mockSource = {
-      history: {
-        go: goMock
-      },
-      location: {
-        pathname: "",
-        search: "",
-        hash: ""
-      }
-    };
+  test("should go to url", () => {
+    const mockSource = createMemorySource("/one");
     const history = createHistory(mockSource);
+    history.navigate("/two");
+    expect(history.location.pathname).toBe("/two");
+  });
+
+  test("should go to previous route", () => {
+    const mockSource = createMemorySource("/one");
+    const history = createHistory(mockSource);
+    history.navigate("/two");
     history.navigate(-1);
-    expect(goMock).toHaveBeenCalledWith(-1);
+    expect(history.location.pathname).toBe("/one");
+  });
+
+  test("should go to next route", () => {
+    const mockSource = createMemorySource("/one");
+    const history = createHistory(mockSource);
+    history.navigate("/two");
+    history.navigate(-1);
+    history.navigate(1);
+    expect(history.location.pathname).toBe("/two");
   });
 });
 


### PR DESCRIPTION
I had error with method `navigate(-1)`. I used `LocationProvider` with custom `history` object. `navigate` from context threw error.