### PR TITLE
Support for named trailing wildcard

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -944,6 +944,18 @@ exports[`trailing wildcard passes down '*' as the prop name if not specified 1`]
 </div>
 `;
 
+exports[`trailing wildcard passes down to Match as unnamed '*' 1`] = `
+<div>
+  i/mean/really/deep
+</div>
+`;
+
+exports[`trailing wildcard passes down to Match as well 1`] = `
+<div>
+  i/mean/really/deep
+</div>
+`;
+
 exports[`trailing wildcard passes down wildcard name to the component as prop 1`] = `
 <div
   role="group"

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -930,6 +930,34 @@ exports[`smoke tests renders the root component at "/" 1`] = `
 </div>
 `;
 
+exports[`trailing wildcard passes down '*' as the prop name if not specified 1`] = `
+<div
+  role="group"
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  README.md
+</div>
+`;
+
+exports[`trailing wildcard passes down wildcard name to the component as prop 1`] = `
+<div
+  role="group"
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  README.md
+</div>
+`;
+
 exports[`transitions keeps the stack right on interrupted transitions 1`] = `
 <div
   role="group"

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -749,3 +749,31 @@ describe("ServerLocation", () => {
     expect(markup).toContain("location.search: [?it=works]");
   });
 });
+
+describe("trailing wildcard", () => {
+  it("passes down wildcard name to the component as prop", () => {
+    const FileBrowser = ({ filePath }) => filePath;
+
+    snapshot({
+      pathname: `/files/README.md`,
+      element: (
+        <Router>
+          <FileBrowser path="files/*filePath" />
+        </Router>
+      )
+    });
+  });
+
+  it("passes down '*' as the prop name if not specified", () => {
+    const FileBrowser = props => props["*"];
+
+    snapshot({
+      pathname: `/files/README.md`,
+      element: (
+        <Router>
+          <FileBrowser path="files/*" />
+        </Router>
+      )
+    });
+  });
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -776,4 +776,26 @@ describe("trailing wildcard", () => {
       )
     });
   });
+
+  it("passes down to Match as well", () => {
+    snapshot({
+      pathname: `/somewhere/deep/i/mean/really/deep`,
+      element: (
+        <Match path="/somewhere/deep/*rest">
+          {props => <div>{props.match.rest}</div>}
+        </Match>
+      )
+    });
+  });
+
+  it("passes down to Match as unnamed '*'", () => {
+    snapshot({
+      pathname: `/somewhere/deep/i/mean/really/deep`,
+      element: (
+        <Match path="/somewhere/deep/*">
+          {props => <div>{props.match["*"]}</div>}
+        </Match>
+      )
+    });
+  });
 });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -58,12 +58,12 @@ let pick = (routes, uri) => {
       let routeSegment = routeSegments[index];
       let uriSegment = uriSegments[index];
 
-      let isSplat = routeSegment === "*";
-      if (isSplat) {
+      if (isSplat(routeSegment)) {
         // Hit a splat, just grab the rest, and return a match
         // uri:   /files/documents/work
         // route: /files/*
-        params["*"] = uriSegments
+        const param = routeSegment.slice(1) || "*";
+        params[param] = uriSegments
           .slice(index)
           .map(decodeURIComponent)
           .join("/");
@@ -223,7 +223,7 @@ let ROOT_POINTS = 1;
 
 let isRootSegment = segment => segment === "";
 let isDynamic = segment => paramRe.test(segment);
-let isSplat = segment => segment === "*";
+let isSplat = segment => segment && segment[0] === "*";
 
 let rankRoute = (route, index) => {
   let score = route.default

--- a/website/src/markdown/api/RouteComponent.md
+++ b/website/src/markdown/api/RouteComponent.md
@@ -2,11 +2,11 @@
 
 Any component passed as a child to `<Router>` is called a "Route Component". There are three types of props for Route Components.
 
-1. **Matching Props** - You provide these props where the `<Router>` is rendered. They are used by `Router` to match the component against the location to see if the component should be rendered. But, they're not really all that important to the component itself. Think of these like the `key` prop in React. Your component doesn't really care about it, but it's information React needs in the parent.
+1.  **Matching Props** - You provide these props where the `<Router>` is rendered. They are used by `Router` to match the component against the location to see if the component should be rendered. But, they're not really all that important to the component itself. Think of these like the `key` prop in React. Your component doesn't really care about it, but it's information React needs in the parent.
 
-2. **Route Props** - These props are passed to your component by `Router` when your component matches the URL: URL parameters and `navigate` are a couple of them. They are all documented on this page.
+2.  **Route Props** - These props are passed to your component by `Router` when your component matches the URL: URL parameters and `navigate` are a couple of them. They are all documented on this page.
 
-3. **Other Props** - Route Components are your own components so go ahead and pass them whatever props they need.
+3.  **Other Props** - Route Components are your own components so go ahead and pass them whatever props they need.
 
 ## path: string
 
@@ -85,7 +85,21 @@ const FileBrowser = props => {
 }
 ```
 
-(Now that I'm writing this doc, should probably allow you to just name it like `/*filePath` ... PRs welcome.)
+You can also name the wildcard portion with suffix.
+
+```jsx
+render(
+  <Router>
+    <FileBrowser path="files/*filePath" />
+  </Router>
+)
+
+const FileBrowser = props => {
+  let filePath = props.filePath
+  // URL: "/files/taxes/2018"
+  // filePath === "taxes/2018"
+}
+```
 
 ## path: "/" (Index Routes)
 


### PR DESCRIPTION
I was reading the doc and spot this issue [here](https://reach.tech/router/api/RouteComponent). Figured that maybe I could help sending PR.

> (Now that I’m writing this doc, should probably allow you to just name it like /*filePath … PRs welcome.)

This PR add support for naming trailing wildcard in `RouteComponent` and `<Match>`.

```diff
render(
  <Router>
-    <FileBrowser path="files/*" />
+    <FileBrowser path="files/*filePath" />
  </Router>
)

const FileBrowser = props => {
-  let filePath = props["*"]
+  let filePath = props.filePath
  // URL: "/files/taxes/2018"
  // filePath === "taxes/2018"
}
```

The change should be backward-compatible and introduce no breaking changes. Since it's stated in the doc as PR-wanted, I didn't open an issue. Hope that I understand the issue correctly?

- [x] Add tests
- [x] Update doc