### PR TITLE
Remove group role from focus wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach/router",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0",
   "description": "Next generation Routing for React.",
   "main": "index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reach/router",
-  "version": "1.3.0-beta.0",
+  "version": "1.3.0-beta.1",
   "description": "Next generation Routing for React.",
   "main": "index.js",
   "module": "es/index.js",

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -20,7 +20,6 @@ exports[`Match matches a path 1`] = `
 
 exports[`Router children allows for fragments 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -36,7 +35,6 @@ exports[`Router children allows for fragments 1`] = `
 
 exports[`Router children ignores falsey chidlren 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -56,7 +54,6 @@ exports[`ServerLocation works 2`] = `"<div style=\\"outline:none\\" tabindex=\\"
 
 exports[`disrespect has complete disrespect for leading and trailing slashes 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -67,7 +64,6 @@ exports[`disrespect has complete disrespect for leading and trailing slashes 1`]
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -78,7 +74,6 @@ exports[`disrespect has complete disrespect for leading and trailing slashes 1`]
       <div>
         Reports 
         <div
-          role="group"
           style={
             Object {
               "outline": "none",
@@ -98,7 +93,6 @@ exports[`disrespect has complete disrespect for leading and trailing slashes 1`]
 
 exports[`links renders links with relative hrefs 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -118,7 +112,6 @@ exports[`links renders links with relative hrefs 1`] = `
       /dash/reports
     </a>
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -145,7 +138,6 @@ exports[`links renders links with relative hrefs 1`] = `
 
 exports[`links uses the right href in multiple root paths 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -159,7 +151,6 @@ exports[`links uses the right href in multiple root paths 1`] = `
       /
     </div>
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -173,7 +164,6 @@ exports[`links uses the right href in multiple root paths 1`] = `
           /
         </div>
         <div
-          role="group"
           style={
             Object {
               "outline": "none",
@@ -187,7 +177,6 @@ exports[`links uses the right href in multiple root paths 1`] = `
               /one
             </div>
             <div
-              role="group"
               style={
                 Object {
                   "outline": "none",
@@ -233,7 +222,6 @@ exports[`links uses the right href in multiple root paths 1`] = `
 
 exports[`location correctly parses pathname, search and hash fields 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -258,7 +246,6 @@ exports[`location correctly parses pathname, search and hash fields 1`] = `
 
 exports[`nested rendering matches multiple nested / down to a child with a path 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -269,7 +256,6 @@ exports[`nested rendering matches multiple nested / down to a child with a path 
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -280,7 +266,6 @@ exports[`nested rendering matches multiple nested / down to a child with a path 
       <div>
         Dash 
         <div
-          role="group"
           style={
             Object {
               "outline": "none",
@@ -300,7 +285,6 @@ exports[`nested rendering matches multiple nested / down to a child with a path 
 
 exports[`nested rendering renders a child 'index' nested path 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -311,7 +295,6 @@ exports[`nested rendering renders a child 'index' nested path 1`] = `
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -329,7 +312,6 @@ exports[`nested rendering renders a child 'index' nested path 1`] = `
 
 exports[`nested rendering renders a nested path 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -340,7 +322,6 @@ exports[`nested rendering renders a nested path 1`] = `
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -358,7 +339,6 @@ exports[`nested rendering renders a nested path 1`] = `
 
 exports[`nested rendering renders a really nested path 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -369,7 +349,6 @@ exports[`nested rendering renders a really nested path 1`] = `
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -380,7 +359,6 @@ exports[`nested rendering renders a really nested path 1`] = `
       <div>
         Reports 
         <div
-          role="group"
           style={
             Object {
               "outline": "none",
@@ -400,7 +378,6 @@ exports[`nested rendering renders a really nested path 1`] = `
 
 exports[`nested rendering renders at a path with nested paths 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -416,7 +393,6 @@ exports[`nested rendering renders at a path with nested paths 1`] = `
 
 exports[`nested rendering yo dawg 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -427,7 +403,6 @@ exports[`nested rendering yo dawg 1`] = `
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -438,7 +413,6 @@ exports[`nested rendering yo dawg 1`] = `
       <div>
         Dash 
         <div
-          role="group"
           style={
             Object {
               "outline": "none",
@@ -458,7 +432,6 @@ exports[`nested rendering yo dawg 1`] = `
 
 exports[`nested rendering yo dawg again 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -469,7 +442,6 @@ exports[`nested rendering yo dawg again 1`] = `
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -480,7 +452,6 @@ exports[`nested rendering yo dawg again 1`] = `
       <div>
         Dash 
         <div
-          role="group"
           style={
             Object {
               "outline": "none",
@@ -500,7 +471,6 @@ exports[`nested rendering yo dawg again 1`] = `
 
 exports[`nested routers allows arbitrary Router nesting through context 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -511,7 +481,6 @@ exports[`nested routers allows arbitrary Router nesting through context 1`] = `
   <div>
     Home
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -529,7 +498,6 @@ exports[`nested routers allows arbitrary Router nesting through context 1`] = `
 
 exports[`passed props parses dynamic segments and passes to components 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -546,7 +514,6 @@ exports[`passed props parses dynamic segments and passes to components 1`] = `
 
 exports[`passed props parses multiple params when nested 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -557,7 +524,6 @@ exports[`passed props parses multiple params when nested 1`] = `
   <div>
     123
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -577,7 +543,6 @@ exports[`passed props parses multiple params when nested 1`] = `
 
 exports[`passed props passes the matched URI to the component 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -604,7 +569,6 @@ exports[`passed props passes the matched URI to the component 1`] = `
 
 exports[`passed props router location prop to nested path 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -615,7 +579,6 @@ exports[`passed props router location prop to nested path 1`] = `
   <div>
     Dash 
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -633,7 +596,6 @@ exports[`passed props router location prop to nested path 1`] = `
 
 exports[`passed props shadows params in nested paths 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -645,7 +607,6 @@ exports[`passed props shadows params in nested paths 1`] = `
     Group: 
     burger
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -664,7 +625,6 @@ exports[`passed props shadows params in nested paths 1`] = `
 
 exports[`relative navigate prop navigates relative 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -681,7 +641,6 @@ exports[`relative navigate prop navigates relative 1`] = `
 
 exports[`relative navigate prop navigates relative 2`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -693,7 +652,6 @@ exports[`relative navigate prop navigates relative 2`] = `
     User:
     123
     <div
-      role="group"
       style={
         Object {
           "outline": "none",
@@ -711,7 +669,6 @@ exports[`relative navigate prop navigates relative 2`] = `
 
 exports[`route ranking / 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -727,7 +684,6 @@ exports[`route ranking / 1`] = `
 
 exports[`route ranking /groups 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -743,7 +699,6 @@ exports[`route ranking /groups 1`] = `
 
 exports[`route ranking /groups/123 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -760,7 +715,6 @@ exports[`route ranking /groups/123 1`] = `
 
 exports[`route ranking /groups/123/users 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -776,7 +730,6 @@ exports[`route ranking /groups/123/users 1`] = `
 
 exports[`route ranking /groups/123/users/456 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -795,7 +748,6 @@ exports[`route ranking /groups/123/users/456 1`] = `
 
 exports[`route ranking /groups/123/users/a/bunch/of/junk 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -811,7 +763,6 @@ exports[`route ranking /groups/123/users/a/bunch/of/junk 1`] = `
 
 exports[`route ranking /groups/123/users/me 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -827,7 +778,6 @@ exports[`route ranking /groups/123/users/me 1`] = `
 
 exports[`route ranking /groups/mine 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -843,7 +793,6 @@ exports[`route ranking /groups/mine 1`] = `
 
 exports[`route ranking /groups/mine/users 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -859,7 +808,6 @@ exports[`route ranking /groups/mine/users 1`] = `
 
 exports[`route ranking /groups/mine/users/me 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -875,7 +823,6 @@ exports[`route ranking /groups/mine/users/me 1`] = `
 
 exports[`route ranking /one/two/three/four/five 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -900,7 +847,6 @@ exports[`route ranking /one/two/three/four/five 1`] = `
 
 exports[`smoke tests renders at a path 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -916,7 +862,6 @@ exports[`smoke tests renders at a path 1`] = `
 
 exports[`smoke tests renders the root component at "/" 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -932,7 +877,6 @@ exports[`smoke tests renders the root component at "/" 1`] = `
 
 exports[`trailing wildcard passes down '*' as the prop name if not specified 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -958,7 +902,6 @@ exports[`trailing wildcard passes down to Match as well 1`] = `
 
 exports[`trailing wildcard passes down wildcard name to the component as prop 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -972,7 +915,6 @@ exports[`trailing wildcard passes down wildcard name to the component as prop 1`
 
 exports[`transitions keeps the stack right on interrupted transitions 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -988,7 +930,6 @@ exports[`transitions keeps the stack right on interrupted transitions 1`] = `
 
 exports[`transitions transitions pages 1`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",
@@ -1004,7 +945,6 @@ exports[`transitions transitions pages 1`] = `
 
 exports[`transitions transitions pages 2`] = `
 <div
-  role="group"
   style={
     Object {
       "outline": "none",

--- a/src/index.js
+++ b/src/index.js
@@ -359,7 +359,6 @@ class FocusHandlerImpl extends React.Component {
       children,
       style,
       requestFocus,
-      role = "group",
       component: Comp = "div",
       uri,
       location,
@@ -370,7 +369,6 @@ class FocusHandlerImpl extends React.Component {
       <Comp
         style={{ outline: "none", ...style }}
         tabIndex="-1"
-        role={role}
         ref={n => (this.node = n)}
         {...domProps}
       >

--- a/website/src/markdown/pages/accessibility.md
+++ b/website/src/markdown/pages/accessibility.md
@@ -21,4 +21,6 @@ When the location changes, the top-most part of your application that changed is
 
 ## Focus Management
 
-Prior to version `1.3.0-beta.1`, we used `role="group"` on the top-level element so that screen readers would announce to the user the focused group's nested elements similarly to how it works when a user loads a page for the first time. A problem we found is that some screen readers (notably VoiceOver and NVDA with Firefox) will read the group's content as if it's a long string, void of any important context provided by the interior markup.
+Prior to version `1.3`, we used `role="group"` on the top-level element so that screen readers would announce to the user the focused group's nested elements similarly to how it works when a user loads a page for the first time. A problem we found is that some screen readers (notably VoiceOver and NVDA with Firefox) will read the group's content as if it's a long string, void of any important context provided by the interior markup.
+
+While we removed the group role as the router's default setting, if you believe the group role creates a better experience for your application you can still pass it as a prop to the `Router` component and it will be forwarded to the top-level element and function the same as before.

--- a/website/src/markdown/pages/accessibility.md
+++ b/website/src/markdown/pages/accessibility.md
@@ -6,10 +6,10 @@ Accessibility is a first-class concern for Reach Router, so, naturally, it's bak
 
 Links in a client rendered app should behave just like links in a server rendered app. Reach Router does this automatically for you:
 
-* Keyboard access
-* Assistive devices announce correctly
-* Command/Control click opens in a new tab
-* Right click "open in new window" opens in a new window
+- Keyboard access
+- Assistive devices announce correctly
+- Command/Control click opens in a new tab
+- Right click "open in new window" opens in a new window
 
 ## Focus Management
 
@@ -17,4 +17,8 @@ Whenever the content of a page changes in response to a user interaction, the fo
 
 Reach Router provides out-of-the-box focus management so your apps are significantly more accessible without you breaking a sweat.
 
-When the location changes, the top-most part of your application that changed is identified and focus is moved to it. Assistive devices then announce to the user the group of elements they are now focused on, similarly to how it works when they load up a page for the first time.
+When the location changes, the top-most part of your application that changed is identified and focus is moved to it.
+
+## Focus Management
+
+Prior to version `1.3.0-beta.1`, we used `role="group"` on the top-level element so that screen readers would announce to the user the focused group's nested elements similarly to how it works when a user loads a page for the first time. A problem we found is that some screen readers (notably VoiceOver and NVDA with Firefox) will read the group's content as if it's a long string, void of any important context provided by the interior markup.


### PR DESCRIPTION
This PR removes the `role="group"` from the router's focus wrapper element. The group role results in some screen readers reading through nested content without context provided by the markup which is pretty confusing as a general setting. 

App developers can still pass a role prop into router if this setting works better for specific use cases, but it seems better to remove it as the default behavior.