### PR TITLE
Crash on old android devices fixed

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -1,6 +1,5 @@
 let getLocation = source => {
   const {
-    pathname,
     search,
     hash,
     href,
@@ -10,6 +9,12 @@ let getLocation = source => {
     hostname,
     port
   } = source.location;
+  let { pathname } = source.location;
+
+  if (!pathname && href && canUseDOM) {
+    const url = new URL(href);
+    pathname = url.pathname;
+  }
 
   return {
     pathname,

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -37,3 +37,22 @@ it("should have a proper search", () => {
   testHistory.navigate("/?asdf");
   expect(testHistory.location.search).toEqual("?asdf");
 });
+
+describe("Location pathname is undefined. Old device.", () => {
+  it("Should works fine", () => {
+    const mockSource = {
+      history: {
+        go: jest.fn()
+      },
+      location: {
+        pathname: undefined,
+        search: "",
+        hash: "",
+        href: "http://localhost/test"
+      }
+    };
+
+    const history = createHistory(mockSource);
+    expect(history.location.pathname).toBe("/test");
+  });
+});


### PR DESCRIPTION
Sometimes window.location.pathname does not exist. I have fixed that case.