### PR TITLE
fix URL with unicode characters in MS Edge

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -1,7 +1,7 @@
 let getLocation = source => {
   const { pathname, search, hash } = source.location;
   return {
-    pathname,
+    pathname: encodeURI(decodeURI(pathname)),
     search,
     hash,
     state: source.history.state,

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -12,6 +12,53 @@ describe("createMemorySource", () => {
   });
 });
 
+describe("createHistory", () => {
+  it("should have location with pathname", () => {
+    const mockSource = {
+      history: {},
+      location: {
+        pathname: "/page",
+        search: "",
+        hash: ""
+      }
+    };
+
+    const history = createHistory(mockSource);
+
+    expect(history.location.pathname).toEqual("/page");
+  });
+
+  it("should encode location pathname", () => {
+    const mockSource = {
+      history: {},
+      location: {
+        pathname: "/påge",
+        search: "",
+        hash: ""
+      }
+    };
+
+    const history = createHistory(mockSource);
+
+    expect(history.location.pathname).toEqual("/p%C3%A5ge");
+  });
+
+  it("should not encode location pathname if it is already encoded", () => {
+    const mockSource = {
+      history: {},
+      location: {
+        pathname: "/p%C3%A5ge",
+        search: "",
+        hash: ""
+      }
+    };
+
+    const history = createHistory(mockSource);
+
+    expect(history.location.pathname).toEqual("/p%C3%A5ge");
+  });
+});
+
 describe("navigate", () => {
   test("navigate with number as a first argument", () => {
     const goMock = jest.fn();
@@ -34,7 +81,6 @@ describe("navigate", () => {
 
 it("should have a proper search", () => {
   const testHistory = createHistory(createMemorySource("/test"));
-  console.log(testHistory);
   testHistory.navigate("/?asdf");
   expect(testHistory.location.search).toEqual("?asdf");
 });


### PR DESCRIPTION
## Description

In MS Edge, the `location.pathname` is not url encoded, but other browsers encode it.
This results in not found route when a url contains a unicode character.

To fix the issue, we now make sure the `pathname` is always encoded, but we also make sure it's not encoded twice.

See unit tests for more details.
I've opened this pull requests without any prior discussion, so feel free to challenge the way this was done !

## Related Issues

This fixes https://github.com/reach/router/issues/343