### PR TITLE
Add failing test for memory source hash

### DIFF
--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -10,6 +10,11 @@ describe("createMemorySource", () => {
     const testHistory = createMemorySource("/test?foo=bar");
     expect(testHistory.location.search).toBe("?foo=bar");
   });
+
+  it("creates a memory source with a hash", () => {
+    const testHistory = createMemorySource("/test?foo=bar#baz");
+    expect(testHistory.location.hash).toBe("#baz");
+  });
 });
 
 describe("createHistory", () => {


### PR DESCRIPTION
I was writing some test using `createMemorySource` when I realized that it doesn't have support for `location.hash`.

I'd be willing to work on adding this functionality if you're open to it.

I apologize if I missed anything!