### PR TITLE
fix: support relative navigation from useNavigate

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -104,6 +104,32 @@ exports[`hooks useLocation returns the location 1`] = `
 </div>
 `;
 
+exports[`hooks useNavigate navigates absolute 1`] = `
+<div
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  IF_THIS_IS_IN_SNAPSHOT_BAAAAADDDDDDDD
+</div>
+`;
+
+exports[`hooks useNavigate navigates absolute 2`] = `
+<div
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  THIS_IS_WHAT_WE_WANT_TO_SEE_IN_SNAPSHOT
+</div>
+`;
+
 exports[`hooks useNavigate navigates relative 1`] = `
 <div
   style={

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -914,7 +914,7 @@ describe("hooks", () => {
   });
 
   describe("useNavigate", () => {
-    it("navigates relative", async () => {
+    it("navigates absolute", async () => {
       let navigate;
 
       const Foo = () => {
@@ -933,6 +933,28 @@ describe("hooks", () => {
       );
       snapshot();
       await navigate("/bar");
+      snapshot();
+    });
+
+    it("navigates relative", async () => {
+      let navigate;
+
+      const FooBar = () => {
+        navigate = useNavigate();
+        return `IF_THIS_IS_IN_SNAPSHOT_BAAAAADDDDDDDD`;
+      };
+
+      const Foo = () => `THIS_IS_WHAT_WE_WANT_TO_SEE_IN_SNAPSHOT`;
+
+      const { snapshot } = runWithNavigation(
+        <Router>
+          <FooBar path="/foo/bar" />
+          <Foo path="/foo" />
+        </Router>,
+        "/foo/bar"
+      );
+      snapshot();
+      await navigate("../");
       snapshot();
     });
   });


### PR DESCRIPTION
This does essentially the same thing as the current `navigate` that's injected as prop does:

https://github.com/reach/router/blob/85f7560bc0b4fd59c439c0c1d0fb5d32c3c273f8/src/index.js#L200-L220

namely resolves the relative url before actually navigating.

I don't think there's an issue for it, but it's been asked about on spectrum: https://spectrum.chat/reach/questions/usenavigate-relative-paths~c46b74be-5867-4135-8087-679af220508f

/cc @jamesportelli