### PR TITLE
Fixes useNavigate inequality with props.navigate

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -935,6 +935,24 @@ describe("hooks", () => {
       await navigate("/bar");
       snapshot();
     });
+    it("is equals to props.navigate for route components", async () => {
+      let navigate;
+      let propNavigate;
+
+      const Foo = props => {
+        navigate = useNavigate();
+        propNavigate = props.navigate;
+        return `Foo`;
+      };
+
+      runWithNavigation(
+        <Router>
+          <Foo path="/foo" />
+        </Router>,
+        "/foo"
+      );
+      expect(navigate).toBe(propNavigate);
+    });
   });
 
   describe("useParams", () => {


### PR DESCRIPTION
### 🔗  Reproduction

Here is the reproduction sendbox https://codesandbox.io/s/reach-router-v133-usenavigate-navigate-issue-sdg3u?file=/src/index.js

###  What's Happening

Version: **1.3.3**

The navigation functions are not matching from hook and props.

`useNavigate !== props.navigate` in the route component.


```jsx
function HomeRoute  (props: RouteComponentProps) {
  const navigate = useNavigate()
  console.log(props.navigate === navigate) // logs `false`
  return <div>Home Page</div>
}
```

### Why

> It's really nice to only have to look into one file for all core related stuff 😄.

 After inspecting the source code, I found the following to be the cause of this bug.

`useNavigate` uses the `LocationContext` to get the navigate function


```js
const useNavigate = () => useContext(LocationContext).navigate
```

And this navigate function is retrieved from the `history` prop of `LocationProvider` which defaults to `globalHistory`.

```jsx
class LocationProvider extends React.Component {
  static defaultProps = {
    history: globalHistory
  }
  state = {
    context: this.getContext()
  }
  getContext() {
    const { navigate, location } = this.props.history;
    return { navigate, location };
  }
  render () {
   return <LocationContext.Provider value={this.state.context}>
     {this.props.children}
   </LocationContext.Provider>
  }
}
```

Now, when rendering our `Router` component and it's children Routes, we are not passing any custom props to this LocationProvider.

```jsx
let Router = props => {
  return <BaseContext.Consumer>
    {baseContext => (
      <LocationContext.Consumer>
        {context =>
          context ? (
            locationContext => (
              <RouterImpl {...baseContext} {...locationContext} {...props} />
            )
          ) : (
            <LocationProvider>
              {locationContext => (
                <RouterImpl {...baseContext} {...locationContext} {...props} />
              )}
            </LocationProvider>
          )}
      </LocationContext.Consumer>
    )}
  </BaseContext.Consumer>
};
```

But when rendering a Route component, the navigate function is resolved to something different.

```jsx
class RouterImpl extends React.PureComponent {
  render () {
    // ...
    // if matched
    let props = {
      ...params,
      uri,
      location,
     // we are resolving the navigate to something else
      navigate: (to, options) => this.props.navigate(resolve(to, uri), options)
    };
    let clone = React.cloneElement(
      element,
      props, // the new navigate gets passed here
      element.props.children ? (
          <Router location={location} primary={primary}>
            {element.props.children}
          </Router>
      ) : (
          undefined
      )
    );
    // ...
  }
}
```

This resolved navigate function only is passed to route component. It does not update the navigate function in `LocationContext` which results in this inequality:

`this.props.navigate !== LocationContext.navigate`

### Resolution

As we can, we need a way to update this navigate function in the LocationContext. I tried to solve this problem in two ways and here are the results:

#### 1: Update the LocationProvider to accept a navigate prop (Failed 😭 )

I update the render method of `RouterImpl` component to wrap the the cloned element with a LocationProvider (modified, which takes a navigate prop along with history) and pass the updated navigate function to it.

```diff
class RouterImpl extends React.Component {
  render () {
      let props = {
        ...params,
        uri,
        location,
        navigate: (to, options) => navigate(resolve(to, uri), options)
      };

      return (
        <BaseContext.Provider value={{ baseuri: uri, basepath }}>
+        <LocationProvider navigate={prop.navigate}>
            <FocusWrapper {...wrapperProps}>{clone}</FocusWrapper>
+        </LocationProvider>
        </BaseContext.Provider>
      );
  }
```

I also updated the `LocationProvider` to accept a navigate prop to set in the context.
```diff
class LocationProvider extends React.Component {
+ getNavigate () {
+   return this.props.navigate || this.props.history.navigate
+ }

  getContext() {
-    let { navigate, location } = this.props.history;
-    return { navigate, location };
+    return { navigate: this.getNavigate(), location: this.props.history };
  }
}
```

But it broke `useLocation`, `useMatch` and some other functionalities. All are having issues with route matching.

My guess after looking into the code of Location and Router component, is that the `LocationProvider` is **NOT** meant to be instantiated multiple times. It has to be singleton.

#### 2: Create a new NavigationContext and set the resolved navigation method in context

```diff
let NavigationContext = createNamedContext("Navigate", globalHistory.navigate);

class RouterImpl extends React.Component {
  render () {
      //...
      return (
        <BaseContext.Provider value={{ baseuri: uri, basepath }}>
+        <NavigationContext navigate={prop.navigate}>
            <FocusWrapper {...wrapperProps}>{clone}</FocusWrapper>
+        </NavigationContext>
        </BaseContext.Provider>
      );   
  }
}
```

and update the `useNavigate` hook to use this context instead of LocationContext

```diff
const useNavigate = () => {
- const context = useContext(LocationContext)
- return context.navigate
+ return useContext(NavigationContext)
}
```

✅  Everything is working as expected and all tests are passing.

### Now What

I have resolved the issue but still there are inconsistencies in the navigation behaviour i.e. the navigate function received in the render props of `Location` component is still the same as globalHistory.navigate received from `LocationContext`.

```jsx
<Location>
  {({ navigate, location}) => {
    // here the navigate is still the same as LocationContext.navigate => globalHistory.context
    // 😢  
  }}
</Location>
```

@ryanflorence  Please have a look.