### PR TITLE
Issue: wrong pathname encoding

### DIFF
--- a/src/lib/history.js
+++ b/src/lib/history.js
@@ -15,9 +15,14 @@ let getLocation = source => {
     const url = new URL(href);
     pathname = url.pathname;
   }
+  
+  const encodedPathname = pathname
+  .split("/")
+  .map(pathPart => encodeURIComponent(decodeURIComponent(pathPart)))
+  .join("/");
 
   return {
-    pathname: encodeURI(decodeURI(pathname)),
+    pathname: encodedPathname,
     search,
     hash,
     href,

--- a/src/lib/history.test.js
+++ b/src/lib/history.test.js
@@ -57,6 +57,22 @@ describe("createHistory", () => {
 
     expect(history.location.pathname).toEqual("/p%C3%A5ge");
   });
+  
+  it("should not encode location pathname if it is already encoded", () => {
+    const mockSource = {
+      history: {},
+      location: {
+        pathname: "/%2F",
+        search: "",
+        hash: ""
+      }
+    };
+
+    const history = createHistory(mockSource);
+
+    expect(history.location.pathname).toEqual("/%2F");
+  });
+  
 });
 
 describe("navigate", () => {


### PR DESCRIPTION
### Reproduction
Live example: https://codesandbox.io/s/reach-router-encoding-issue-pofyo

### What's Happening
Version: 1.3.3

The encoding on pathname fails when the URL contains `%2F`, and returns the pathname with `%252F` instead. 
This is because
`encodeURI(decodeURI('%2F')) === "%252F"`