### PR TITLE
Issue: useParams sometimes null with embedded router

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -955,6 +955,43 @@ describe("hooks", () => {
     });
   });
 
+  it("useParams with embedded router", () => {
+    let contentProps;
+    let contentParams;
+    let contentRouterProps;
+    let contentRouterParams;
+
+    const ContentRouter = props => {
+      contentRouterProps = props;
+      contentRouterParams = useParams();
+      return (
+        <Router>
+          <Content path=":someOtherParam" />
+        </Router>
+      );
+    };
+
+    const Content = props => {
+      contentProps = props;
+      contentParams = useParams();
+      return JSON.stringify(contentParams);
+    };
+
+    runWithNavigation(
+      <Router>
+        <ContentRouter path=":someParam/*" />
+      </Router>,
+      "/foo/bar"
+    );
+
+    expect(contentRouterProps.someParam).toEqual("foo");
+    expect(contentProps.someParam).toEqual("foo");
+    expect(contentProps.someOtherParam).toEqual("bar");
+    // Failing check
+    expect(contentRouterParams).toEqual({ someParam: "foo" });
+    expect(contentParams).toEqual({ someParam: "foo", someOtherParam: "bar" });
+  });
+
   describe("useMatch", () => {
     it("matches on direct routes", async () => {
       let match;


### PR DESCRIPTION
## Reproduction

https://codesandbox.io/s/reach-router-params-bug-pc59h

To reproduce, visit `/foo/bar`. ContentRouter params should be `{ someParam: "foo" }` but is instead `null`.

This PR also includes a failing test with the same example.

## Issue

It seems that `useParams` isn't always detecting all current params even when params are properly passed into the component through props. I believe this is because of ContentRouter's path of `:someParam/*` - ContentRouter is expecting a single param due to the `*` but is instead receiving two.

Not sure if this is expected behavior, but it's frustrating having `useParams` behave inconsistently, especially in deeply nested cases where `someParam` wouldn't be accessible via props.