### PR TITLE
Show an error message if accessing location.href when using ServerLocation

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -829,6 +829,24 @@ describe("ServerLocation", () => {
     expect(markup).toContain("location.pathname: [/print-location]");
     expect(markup).toContain("location.search: [?it=works]");
   });
+
+  test("location.href fails", () => {
+    let PrintHref = ({ location }) => (
+      <div>location.href: [{location.href}]</div>
+    );
+
+    const path = "/path";
+
+    expect(() =>
+      renderToStaticMarkup(
+        <ServerLocation url={path}>
+          <Router>
+            <PrintHref path={path} />
+          </Router>
+        </ServerLocation>
+      )
+    ).toThrow("location.href not available on the server.");
+  });
 });
 
 describe("trailing wildcard", () => {


### PR DESCRIPTION
(as well as when trying to access any other properties that are not available on location server side)

Depending on which Node version you require, `isProxySupported` may be unnecessary. 