### PR TITLE
Support React 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,13 @@
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "create-react-context": "^0.3.0"
+  },
+  "peerDependenciesMeta": {
+    "create-react-context": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -42,6 +48,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "create-react-context": "^0.3.0",
     "eslint": "^4.18.2",
     "eslint-config-react-app": "^2.1.0",
     "eslint-plugin-flowtype": "^2.34.1",
@@ -80,7 +87,6 @@
     "printWidth": 80
   },
   "dependencies": {
-    "create-react-context": "0.3.0",
     "invariant": "^2.2.3",
     "prop-types": "^15.6.1",
     "react-lifecycles-compat": "^3.0.4"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "testURL": "http://localhost"
   },
   "peerDependencies": {
-    "react": "15.x || 16.x || 16.4.0-alpha.0911da3",
-    "react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
This is a WIP (work in progress) PR, due to the `create-react-context` dependency still needing to be addressed. Currently, it does not have React 17 support, and the next version number has yet to be confirmed.

Here are some options to handle this:
1) hope/assume that an "0.x" release comes out
```
"dependencies": {
    "create-react-context": "^0.3.0",
  },
```
2) confirming the intended version of `create-react-context` with React 17 support and using a `||` in dependencies. 
```
"dependencies": {
    "create-react-context": "0.3.0 || [expected-version-with-react-17-support]",
  },
```
3) leave PR open until next release and reference it explicitly.
4) other...?

Please share your thoughts and feedback.

Resolves #429