### PR TITLE
apply #104 to correctly pass component prop to Router

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -227,7 +227,11 @@ class RouterImpl extends React.PureComponent {
         element,
         props,
         element.props.children ? (
-          <Router location={location} primary={primary}>
+          <Router
+            location={location}
+            primary={primary}
+            component={!primary ? component : undefined}
+          >
             {element.props.children}
           </Router>
         ) : (


### PR DESCRIPTION
fixes #63
replaces #104 
see also: https://github.com/databyss-org/reach-router/blob/pzhine/release-1.3.4-b1/README.md