### PR TITLE
chore(tests): support relative navigation from useNavigate

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -104,6 +104,32 @@ exports[`hooks useLocation returns the location 1`] = `
 </div>
 `;
 
+exports[`hooks useNavigate navigates absolute 1`] = `
+<div
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  IF_THIS_IS_IN_SNAPSHOT_BAAAAADDDDDDDD
+</div>
+`;
+
+exports[`hooks useNavigate navigates absolute 2`] = `
+<div
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  THIS_IS_WHAT_WE_WANT_TO_SEE_IN_SNAPSHOT
+</div>
+`;
+
 exports[`hooks useNavigate navigates relative 1`] = `
 <div
   style={

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -914,7 +914,7 @@ describe("hooks", () => {
   });
 
   describe("useNavigate", () => {
-    it("navigates relative", async () => {
+    it("navigates absolute", async () => {
       let navigate;
 
       const Foo = () => {
@@ -935,6 +935,29 @@ describe("hooks", () => {
       await navigate("/bar");
       snapshot();
     });
+
+    it("navigates relative", async () => {
+      let navigate;
+
+      const FooBar = () => {
+        navigate = useNavigate();
+        return `IF_THIS_IS_IN_SNAPSHOT_BAAAAADDDDDDDD`;
+      };
+
+      const Foo = () => `THIS_IS_WHAT_WE_WANT_TO_SEE_IN_SNAPSHOT`;
+
+      const { snapshot } = runWithNavigation(
+        <Router>
+          <FooBar path="/foo/bar" />
+          <Foo path="/foo" />
+        </Router>,
+        "/foo/bar"
+      );
+      snapshot();
+      await navigate("../");
+      snapshot();
+    });
+
     it("is equals to props.navigate for route components", async () => {
       let navigate;
       let propNavigate;


### PR DESCRIPTION
The test from #374. As noted in https://github.com/reach/router/pull/374#issuecomment-649728497 teh issues is fixed in master (although unreleased for some reason), but the broken behavior did not get a test