### PR TITLE
Dynamic segments called "key" are silently removed

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -564,6 +564,32 @@ exports[`passed props parses dynamic segments and passes to components 1`] = `
 </div>
 `;
 
+exports[`passed props parses dynamic segments and passes to components, even if called 'key' 1`] = `
+<div
+  style={
+    Object {
+      "outline": "none",
+    }
+  }
+  tabIndex="-1"
+>
+  <pre>
+    {
+  "path": "/foo/:bar/keychain/:key",
+  "bar": "987",
+  "key": "123",
+  "uri": "/foo/987/keychain/123",
+  "location": {
+    "pathname": "foo/987/keychain/123",
+    "search": "",
+    "state": null,
+    "key": "initial"
+  }
+}
+  </pre>
+</div>
+`;
+
 exports[`passed props parses multiple params when nested 1`] = `
 <div
   style={

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -129,6 +129,17 @@ describe("passed props", () => {
     });
   });
 
+  it("parses dynamic segments and passes to components, even if called 'key'", () => {
+    snapshot({
+      pathname: "foo/987/keychain/123",
+      element: (
+        <Router>
+          <PropsPrinter path="/foo/:bar/keychain/:key" />
+        </Router>
+      )
+    });
+  });
+
   it("passes the matched URI to the component", () => {
     snapshot({
       pathname: "/groups/123/users/456",


### PR DESCRIPTION
If a dynamic segment is called “key” it will be silently removed from the props.

`/some-path/:foo/bar/:key` — would include `foo` in the props passed to the child component but not `key`. 

**The docs state:**

> Reserved Names: You can name your parameters anything want except uri and path. You’ll get a warning if you try, so don’t worry if you didn’t actually read these docs (… 🤔).

I’m assuming that this issue happens due to a clash with React? However, a dynamic segment called e.g. `className` seems to be passed fine.

My suggestion would be to either find a way to pass the parameter as any other or include a note in the documentation. `key` might be a more common parameter name than others.

Attached is a failing test. Additionally — and maybe easier — you can see the issue here: https://codesandbox.io/s/mystifying-golick-fchxm?file=/src/App.js