### PR TITLE
Fix typo: incorrect matching delimiter

### DIFF
--- a/website/src/markdown/api/useLocation.md
+++ b/website/src/markdown/api/useLocation.md
@@ -13,5 +13,5 @@ const useAnalytics = (props) => {
   useEffect(() => {
     ga.send(['pageview', location.pathname]);
   }, [])
-)
+}
 ```


### PR DESCRIPTION
Arrow function opens with a curly brace, but was closed with a parenthesis.