### PR TITLE
Fix `this.unmounted` being true when re-mounted by React 18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,7 @@ class LocationProvider extends React.Component {
       state: { refs },
       props: { history }
     } = this;
+    this.unmounted = false;
     history._onTransitionComplete();
     refs.unlisten = history.listen(() => {
       Promise.resolve().then(() => {


### PR DESCRIPTION
I understand that you are spending your time now on React Router v6, but it would be very nice to have this in still.
This one line change made my app go from "Reach Router not doing anything at all" to working perfectly on React 18.

React 18 can render componentWillUnmount and then componentDidMount the same instance that was just "willUnmount"-ed.
This makes sure we reset `this.unmounted = false` when re-didMount-ing.