### PR TITLE
[Fix] calling navigate with number throws

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -142,7 +142,7 @@ let match = (path, uri) => pick([{ path }], uri);
 // require less contextual information and (fingers crossed) be more intuitive.
 let resolve = (to, base) => {
   // /foo/bar, /baz/qux => /foo/bar
-  if (startsWith(to, "/")) {
+  if (typeof to === "number" || startsWith(to, "/")) {
     return to;
   }
 

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -84,6 +84,7 @@ describe("resolve", () => {
     expect(resolve("/groups?some=query", "/users?some=thing")).toEqual(
       "/groups?some=query"
     );
+    expect(resolve(-1)).toEqual(-1);
   });
 });
 


### PR DESCRIPTION
Hello, first thank you for the wonderful job I am using reach router for more than a year now and I am super happy with it ! 👏 

I am raising this pull request as I faced an issue using `navigate` function with a `number`

## The issue

When calling the function `navigate` with a `number` as it is mentioned in the [documentation](https://reach.tech/router/api/navigate)

>You can pass a number to go to a previously visited route.
`navigate(-1)`

It results into a crash because the function `startsWith` requires a `string` and is called with `to` argument

<img width="737" alt="reach-router-exception-navigate-number" src="https://user-images.githubusercontent.com/1875595/165089170-6db5e22b-b4a6-4db5-85fc-a1f9c316f7c7.png">


## The fix

Escaping the case where `to` argument is a `number`